### PR TITLE
Update Module.sdf3

### DIFF
--- a/dynsem/syntax/Module.sdf3
+++ b/dynsem/syntax/Module.sdf3
@@ -29,7 +29,7 @@ context-free syntax
   ModuleID = "namespaces" {reject}
   ModuleID = "properties" {reject}
   ModuleID = "imports"    {reject}
-  ModuleID = "signatures" {reject}
+  ModuleID = "signature" {reject}
   
   ID = "rule" {reject}
 


### PR DESCRIPTION
I think you misspelled there, as there is no signatureS keyword in the syntax.
This led me to an ambiguity when I was trying to generate a file with only ds signatures out of an SDF3 grammar.
