### PR TITLE
Origin tracking

### DIFF
--- a/dynsem/trans/backend/java-backend/emit-execmethods.str
+++ b/dynsem/trans/backend/java-backend/emit-execmethods.str
@@ -361,7 +361,7 @@ rules
     VarRef(x_vref) -> e |[ x_vref ]|
   
   ds2java-term-build(|ex_ty):
-    Con(c, child*) -> e |[ new x_consclass(null, e*) ]|
+    Con(c, child*) -> e |[ new x_consclass(this.getSourceInfo(), e*) ]|
     where
       c-def := <lookup-def(|Constructors())> c;
       c-kind := <lookup-prop(|ConsKind())> c-def;

--- a/org.metaborg.meta.interpreter.framework/src/org/metaborg/meta/interpreter/framework/NodeSource.java
+++ b/org.metaborg.meta.interpreter.framework/src/org/metaborg/meta/interpreter/framework/NodeSource.java
@@ -64,7 +64,7 @@ public class NodeSource implements INodeSource {
 			OriginAttachment originAttachment = aterm.getAttachment(OriginAttachment.TYPE);
 			imploderAttachment = originAttachment.getOrigin().getAttachment(ImploderAttachment.TYPE);
 			attachment = originAttachment;
-		} else if ( aterm.getAttachment(OriginAttachment.TYPE) != null ) {
+		} else if ( aterm.getAttachment(ImploderAttachment.TYPE) != null ) {
 			imploderAttachment = aterm.getAttachment(ImploderAttachment.TYPE);
 			attachment = imploderAttachment;
 		}


### PR DESCRIPTION
Some more origin related changes.
- The condition in NodeSource checked for the wrong attachment.
- Origin information is now propagated if new nodes are created.
