### PR TITLE
Syntactic improvements (Nullary constructors, internal-*)

### DIFF
--- a/dynsem/src-gen/completions/Signatures-esv.esv
+++ b/dynsem/src-gen/completions/Signatures-esv.esv
@@ -18,8 +18,10 @@ completions
 completions
   completion template SignatureSection : "constructors " =
     "constructors\n\t" (cursor) (blank)  
-  completion template ConsDecl : "ID : -> Type" =
-    <ID:ID> " : " <:Type> " -> " <Type:Type>  
+  completion template ConsDecl : "ID : Type -> Type" =
+    <ID:ID> " : " <Type:Type> " -> " <Type:Type>  
+  completion template ConsDecl : "ID : Type" =
+    <ID:ID> " : " <Type:Type>  
   completion template Type : "List(Type)" =
     "List(" <Type:Type> ")"  
   completion template MapType : "Map<Type,Type>" =
@@ -52,20 +54,26 @@ completions
 completions
   completion template SignatureSection : "native-operators " =
     "native-operators\n\t" (cursor) (blank)  
-  completion template NativeOpDecl : "ID : -> Type" =
-    <ID:ID> " : " <:Type> " -> " <Type:Type>  
+  completion template NativeOpDecl : "ID : Type -> Type" =
+    <ID:ID> " : " <Type:Type> " -> " <Type:Type>  
+  completion template NativeOpDecl : "ID : Type" =
+    <ID:ID> " : " <Type:Type>  
 
 completions
   completion template SignatureSection : "internal-constructors " =
     "internal-constructors\n\t" (cursor) (blank)  
-  completion template InternalConsDecl : "ID : -> Type" =
-    <ID:ID> " : " <:Type> " -> " <Type:Type>  
+  completion template InternalConsDecl : "ID : Type -> Type" =
+    <ID:ID> " : " <Type:Type> " -> " <Type:Type>  
+  completion template InternalConsDecl : "ID : Type" =
+    <ID:ID> " : " <Type:Type>  
 
 completions
   completion template SignatureSection : "native-constructors " =
     "native-constructors\n\t" (cursor) (blank)  
-  completion template NativeConsDecl : "ID : -> Type" =
-    <ID:ID> " : " <:Type> " -> " <Type:Type>  
+  completion template NativeConsDecl : "ID : Type -> Type" =
+    <ID:ID> " : " <Type:Type> " -> " <Type:Type>  
+  completion template NativeConsDecl : "ID : Type" =
+    <ID:ID> " : " <Type:Type>  
 
 completions
   completion template SignatureSection : "arrows " =

--- a/dynsem/src-gen/completions/Signatures-esv.esv
+++ b/dynsem/src-gen/completions/Signatures-esv.esv
@@ -1,4 +1,3 @@
-
 module src-gen/completions/Signatures-esv
 
 imports
@@ -34,12 +33,6 @@ completions
     <ID:ID> " -> " <MapType:MapType>  
 
 completions
-  completion template SignatureSection : "internal-sorts " =
-    "internal-sorts\n\t" (cursor) (blank)  
-  completion template InternalSortDecl : "ID -> ID" =
-    <ID:ID> " -> " <ID:ID>  
-
-completions
   completion template SignatureSection : "native-datatypes " =
     "native-datatypes\n\t" (cursor) (blank)  
   completion template NativeTypeDecl : "JSNIPPET as ID { } " =
@@ -60,14 +53,6 @@ completions
     <ID:ID> " : " <Type:Type>  
 
 completions
-  completion template SignatureSection : "internal-constructors " =
-    "internal-constructors\n\t" (cursor) (blank)  
-  completion template InternalConsDecl : "ID : Type -> Type" =
-    <ID:ID> " : " <Type:Type> " -> " <Type:Type>  
-  completion template InternalConsDecl : "ID : Type" =
-    <ID:ID> " : " <Type:Type>  
-
-completions
   completion template SignatureSection : "native-constructors " =
     "native-constructors\n\t" (cursor) (blank)  
   completion template NativeConsDecl : "ID : Type -> Type" =
@@ -77,10 +62,8 @@ completions
 
 completions
   completion template SignatureSection : "arrows " =
-    "arrows\n\t" (cursor) (blank)             
+    "arrows\n\t" (cursor) (blank)  
   completion template ArrowDeclaration : "Type -ID-> Type" =
     <Type:Type> " -" <ID:ID> "-> " <Type:Type>  
   completion template ArrowDeclaration : "Type --> Type" =
-    <Type:Type> " --> " <Type:Type>     
-  completion template ArrowTemplateDeclaration : "forall ID, Type -ID(ID -> ID)-> Type" =
-    "forall " <ID:ID> ", " <Type:Type> " -" <ID:ID> "(" <ID:ID> " -> " <ID:ID> ")-> " <Type:Type>  
+    <Type:Type> " --> " <Type:Type>  

--- a/dynsem/src-gen/pp/Signatures-pp.str
+++ b/dynsem/src-gen/pp/Signatures-pp.str
@@ -247,55 +247,6 @@ strategies
     prettyprint-SignatureSection
 
   prettyprint-example =
-    prettyprint-InternalSortDecl
-
-  prettyprint-SignatureSection :
-    InternalSorts(t1__) -> [ H(
-                               [SOpt(HS(), "0")]
-                             , [S("internal-sorts")]
-                             )
-                           , t1__'
-                           ]
-    with t1__' := <pp-indent(|"2")> [<pp-V-list(prettyprint-InternalSortDecl)> t1__]
-
-  is-SignatureSection =
-    ?InternalSorts(_)
-
-  prettyprint-InternalSortDecl :
-    InternalSortDecl(t1__) -> [ H(
-                                  [SOpt(HS(), "0")]
-                                , [t1__']
-                                )
-                              ]
-    with t1__' := <pp-one-Z(prettyprint-ID)> t1__
-
-  is-InternalSortDecl =
-    ?InternalSortDecl(_)
-
-  prettyprint-InternalSortDecl :
-    InternalInjDecl(t1__, t2__) -> [ H(
-                                       [SOpt(HS(), "0")]
-                                     , [t1__', S(" -> "), t2__']
-                                     )
-                                   ]
-    with t1__' := <pp-one-Z(prettyprint-ID)> t1__
-    with t2__' := <pp-one-Z(prettyprint-ID)> t2__
-
-  is-InternalSortDecl =
-    ?InternalInjDecl(_, _)
-
-  is-SignatureSection =
-    fail
-
-  is-InternalSortDecl =
-    fail
-
-
-strategies
-  prettyprint-example =
-    prettyprint-SignatureSection
-
-  prettyprint-example =
     prettyprint-JSNIPPET
 
   prettyprint-example =
@@ -470,62 +421,6 @@ strategies
     prettyprint-SignatureSection
 
   prettyprint-example =
-    prettyprint-InternalConsDecl
-
-  prettyprint-SignatureSection :
-    InternalConstructors(t1__) -> [ H(
-                                      [SOpt(HS(), "0")]
-                                    , [S("internal-constructors")]
-                                    )
-                                  , t1__'
-                                  ]
-    with t1__' := <pp-indent(|"2")> [<pp-V-list(prettyprint-InternalConsDecl)> t1__]
-
-  is-SignatureSection =
-    ?InternalConstructors(_)
-
-  prettyprint-InternalConsDecl :
-    InternalConsDecl(t1__, t2__, t3__) -> [ H(
-                                              [SOpt(HS(), "0")]
-                                            , [ t1__'
-                                              , S(" : ")
-                                              , t2__'
-                                              , S(" -> ")
-                                              , t3__'
-                                              ]
-                                            )
-                                          ]
-    with t1__' := <pp-one-Z(prettyprint-ID)> t1__
-    with t2__' := <pp-H-list(prettyprint-Type|" * ")> t2__
-    with t3__' := <pp-one-Z(prettyprint-Type)> t3__
-
-  is-InternalConsDecl =
-    ?InternalConsDecl(_, _, _)
-
-  prettyprint-InternalConsDecl :
-    NullaryInternalConsDecl(t1__, t2__) -> [ H(
-                                               [SOpt(HS(), "0")]
-                                             , [t1__', S(" : "), t2__']
-                                             )
-                                           ]
-    with t1__' := <pp-one-Z(prettyprint-ID)> t1__
-    with t2__' := <pp-one-Z(prettyprint-Type)> t2__
-
-  is-InternalConsDecl =
-    ?NullaryInternalConsDecl(_, _)
-
-  is-SignatureSection =
-    fail
-
-  is-InternalConsDecl =
-    fail
-
-
-strategies
-  prettyprint-example =
-    prettyprint-SignatureSection
-
-  prettyprint-example =
     prettyprint-NativeConsDecl
 
   prettyprint-SignatureSection :
@@ -587,9 +482,6 @@ strategies
   prettyprint-example =
     prettyprint-ArrowDeclaration
 
-  prettyprint-example =
-    prettyprint-ArrowTemplateDeclaration
-
   prettyprint-SignatureSection :
     ArrowDeclarations(t1__) -> [ H(
                                    [SOpt(HS(), "0")]
@@ -610,15 +502,6 @@ strategies
             ]
     where not(is-DeclaredArrow)
     where t1__' := <pp-one-Z(prettyprint-ArrowDeclaration)> t1__
-
-  prettyprint-DeclaredArrow :
-    t1__ -> [ H(
-                [SOpt(HS(), "0")]
-              , [t1__']
-              )
-            ]
-    where not(is-DeclaredArrow)
-    where t1__' := <pp-one-Z(prettyprint-ArrowTemplateDeclaration)> t1__
 
   prettyprint-ArrowDeclaration :
     ArrowDecl(t1__, t2__, t3__) -> [ H(
@@ -650,34 +533,6 @@ strategies
   is-ArrowDeclaration =
     ?DefaultArrowDecl(_, _)
 
-  prettyprint-ArrowTemplateDeclaration :
-    ArrowTemplDecl(t1__, t2__, t3__, t4__, t5__, t6__) -> [ H(
-                                                              [SOpt(HS(), "0")]
-                                                            , [ S("forall ")
-                                                              , t1__'
-                                                              , S(", ")
-                                                              , t2__'
-                                                              , S(" -")
-                                                              , t3__'
-                                                              , S("(")
-                                                              , t4__'
-                                                              , S(" -> ")
-                                                              , t5__'
-                                                              , S(")-> ")
-                                                              , t6__'
-                                                              ]
-                                                            )
-                                                          ]
-    with t1__' := <pp-H-list(prettyprint-ID|" ")> t1__
-    with t2__' := <pp-one-Z(prettyprint-Type)> t2__
-    with t3__' := <pp-one-Z(prettyprint-ID)> t3__
-    with t4__' := <pp-one-Z(prettyprint-ID)> t4__
-    with t5__' := <pp-one-Z(prettyprint-ID)> t5__
-    with t6__' := <pp-one-Z(prettyprint-Type)> t6__
-
-  is-ArrowTemplateDeclaration =
-    ?ArrowTemplDecl(_, _, _, _, _, _)
-
   is-SignatureSection =
     fail
 
@@ -685,7 +540,4 @@ strategies
     fail
 
   is-ArrowDeclaration =
-    fail
-
-  is-ArrowTemplateDeclaration =
     fail

--- a/dynsem/src-gen/pp/Signatures-pp.str
+++ b/dynsem/src-gen/pp/Signatures-pp.str
@@ -128,6 +128,18 @@ strategies
   is-ConsDecl =
     ?ConsDecl(_, _, _)
 
+  prettyprint-ConsDecl :
+    NullaryConsDecl(t1__, t2__) -> [ H(
+                                       [SOpt(HS(), "0")]
+                                     , [t1__', S(" : "), t2__']
+                                     )
+                                   ]
+    with t1__' := <pp-one-Z(prettyprint-ID)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Type)> t2__
+
+  is-ConsDecl =
+    ?NullaryConsDecl(_, _)
+
   prettyprint-Type :
     SimpleSort(t1__) -> [ H(
                             [SOpt(HS(), "0")]
@@ -434,6 +446,18 @@ strategies
   is-NativeOpDecl =
     ?NativeOpDecl(_, _, _)
 
+  prettyprint-NativeOpDecl :
+    NullaryNativeOpDecl(t1__, t2__) -> [ H(
+                                           [SOpt(HS(), "0")]
+                                         , [t1__', S(" : "), t2__']
+                                         )
+                                       ]
+    with t1__' := <pp-one-Z(prettyprint-ID)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Type)> t2__
+
+  is-NativeOpDecl =
+    ?NullaryNativeOpDecl(_, _)
+
   is-SignatureSection =
     fail
 
@@ -478,6 +502,18 @@ strategies
   is-InternalConsDecl =
     ?InternalConsDecl(_, _, _)
 
+  prettyprint-InternalConsDecl :
+    NullaryInternalConsDecl(t1__, t2__) -> [ H(
+                                               [SOpt(HS(), "0")]
+                                             , [t1__', S(" : "), t2__']
+                                             )
+                                           ]
+    with t1__' := <pp-one-Z(prettyprint-ID)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Type)> t2__
+
+  is-InternalConsDecl =
+    ?NullaryInternalConsDecl(_, _)
+
   is-SignatureSection =
     fail
 
@@ -521,6 +557,18 @@ strategies
 
   is-NativeConsDecl =
     ?NativeConsDecl(_, _, _)
+
+  prettyprint-NativeConsDecl :
+    NullaryNativeConsDecl(t1__, t2__) -> [ H(
+                                             [SOpt(HS(), "0")]
+                                           , [t1__', S(" : "), t2__']
+                                           )
+                                         ]
+    with t1__' := <pp-one-Z(prettyprint-ID)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Type)> t2__
+
+  is-NativeConsDecl =
+    ?NullaryNativeConsDecl(_, _)
 
   is-SignatureSection =
     fail

--- a/dynsem/src-gen/signatures/Signatures-sig.str
+++ b/dynsem/src-gen/signatures/Signatures-sig.str
@@ -15,12 +15,13 @@ signature
     InjDecl  : ID * ID -> SortDecl
 
   constructors
-    Constructors : List(ConsDecl) -> SignatureSection
-    ConsDecl     : ID * List(Type) * Type -> ConsDecl
-    SimpleSort   : ID -> Type
-    ListSort     : Type -> Type
-                 : MapType -> Type
-    MapSort      : Type * Type -> MapType
+    Constructors    : List(ConsDecl) -> SignatureSection
+    ConsDecl        : ID * List(Type) * Type -> ConsDecl
+    NullaryConsDecl : ID * Type -> ConsDecl
+    SimpleSort      : ID -> Type
+    ListSort        : Type -> Type
+                    : MapType -> Type
+    MapSort         : Type * Type -> MapType
 
   constructors
     SemanticComponents : List(SemanticCompDecl) -> SignatureSection
@@ -40,16 +41,19 @@ signature
     NativeNoArgFunctionDecl : ID * Type -> NativeFunctionDecl
 
   constructors
-    NativeOperators : List(NativeOpDecl) -> SignatureSection
-    NativeOpDecl    : ID * List(Type) * Type -> NativeOpDecl
+    NativeOperators     : List(NativeOpDecl) -> SignatureSection
+    NativeOpDecl        : ID * List(Type) * Type -> NativeOpDecl
+    NullaryNativeOpDecl : ID * Type -> NativeOpDecl
 
   constructors
-    InternalConstructors : List(InternalConsDecl) -> SignatureSection
-    InternalConsDecl     : ID * List(Type) * Type -> InternalConsDecl
+    InternalConstructors    : List(InternalConsDecl) -> SignatureSection
+    InternalConsDecl        : ID * List(Type) * Type -> InternalConsDecl
+    NullaryInternalConsDecl : ID * Type -> InternalConsDecl
 
   constructors
-    NativeConstructors : List(NativeConsDecl) -> SignatureSection
-    NativeConsDecl     : ID * List(Type) * Type -> NativeConsDecl
+    NativeConstructors    : List(NativeConsDecl) -> SignatureSection
+    NativeConsDecl        : ID * List(Type) * Type -> NativeConsDecl
+    NullaryNativeConsDecl : ID * Type -> NativeConsDecl
 
   constructors
     ArrowDeclarations : List(DeclaredArrow) -> SignatureSection

--- a/dynsem/src-gen/signatures/Signatures-sig.str
+++ b/dynsem/src-gen/signatures/Signatures-sig.str
@@ -28,11 +28,6 @@ signature
     SemanticComponent  : ID * MapType -> SemanticCompDecl
 
   constructors
-    InternalSorts    : List(InternalSortDecl) -> SignatureSection
-    InternalSortDecl : ID -> InternalSortDecl
-    InternalInjDecl  : ID * ID -> InternalSortDecl
-
-  constructors
     NativeDataTypes         : List(NativeTypeDecl) -> SignatureSection
                             : STRING -> JSNIPPET
     NativeBaseTypeDecl      : JSNIPPET * ID * List(NativeFunctionDecl) -> NativeTypeDecl
@@ -46,11 +41,6 @@ signature
     NullaryNativeOpDecl : ID * Type -> NativeOpDecl
 
   constructors
-    InternalConstructors    : List(InternalConsDecl) -> SignatureSection
-    InternalConsDecl        : ID * List(Type) * Type -> InternalConsDecl
-    NullaryInternalConsDecl : ID * Type -> InternalConsDecl
-
-  constructors
     NativeConstructors    : List(NativeConsDecl) -> SignatureSection
     NativeConsDecl        : ID * List(Type) * Type -> NativeConsDecl
     NullaryNativeConsDecl : ID * Type -> NativeConsDecl
@@ -58,7 +48,5 @@ signature
   constructors
     ArrowDeclarations : List(DeclaredArrow) -> SignatureSection
                       : ArrowDeclaration -> DeclaredArrow
-                      : ArrowTemplateDeclaration -> DeclaredArrow
     ArrowDecl         : Type * ID * Type -> ArrowDeclaration
     DefaultArrowDecl  : Type * Type -> ArrowDeclaration
-    ArrowTemplDecl    : List(ID) * Type * ID * ID * ID * Type -> ArrowTemplateDeclaration

--- a/dynsem/src-gen/syntax/Signatures.sdf
+++ b/dynsem/src-gen/syntax/Signatures.sdf
@@ -20,7 +20,8 @@ exports
 
   context-free syntax
     "constructors" ConsDecl*     -> SignatureSection {cons("Constructors")}
-    ID ":" {Type "*"}* "->" Type -> ConsDecl         {cons("ConsDecl")}
+    ID ":" {Type "*"}+ "->" Type -> ConsDecl         {cons("ConsDecl")}
+    ID ":" Type                  -> ConsDecl         {cons("NullaryConsDecl")}
     ID                           -> Type             {cons("SimpleSort")}
     "List" "(" Type ")"          -> Type             {cons("ListSort")}
     MapType                      -> Type             
@@ -65,7 +66,8 @@ exports
 
   context-free syntax
     "native-operators" NativeOpDecl* -> SignatureSection {cons("NativeOperators")}
-    ID ":" {Type "*"}* "->" Type     -> NativeOpDecl     {cons("NativeOpDecl")}
+    ID ":" {Type "*"}+ "->" Type     -> NativeOpDecl     {cons("NativeOpDecl")}
+    ID ":" Type                      -> NativeOpDecl     {cons("NullaryNativeOpDecl")}
 
   context-free syntax
     CONTENTCOMPLETE -> SignatureSection {cons("COMPLETION-SignatureSection")}
@@ -73,7 +75,8 @@ exports
 
   context-free syntax
     "internal-constructors" InternalConsDecl* -> SignatureSection {cons("InternalConstructors")}
-    ID ":" {Type "*"}* "->" Type              -> InternalConsDecl {cons("InternalConsDecl")}
+    ID ":" {Type "*"}+ "->" Type              -> InternalConsDecl {cons("InternalConsDecl")}
+    ID ":" Type                               -> InternalConsDecl {cons("NullaryInternalConsDecl")}
 
   context-free syntax
     CONTENTCOMPLETE -> SignatureSection {cons("COMPLETION-SignatureSection")}
@@ -81,7 +84,8 @@ exports
 
   context-free syntax
     "native-constructors" NativeConsDecl* -> SignatureSection {cons("NativeConstructors")}
-    ID ":" {Type "*"}* "->" Type          -> NativeConsDecl   {cons("NativeConsDecl")}
+    ID ":" {Type "*"}+ "->" Type          -> NativeConsDecl   {cons("NativeConsDecl")}
+    ID ":" Type                           -> NativeConsDecl   {cons("NullaryNativeConsDecl")}
 
   context-free syntax
     CONTENTCOMPLETE -> SignatureSection {cons("COMPLETION-SignatureSection")}

--- a/dynsem/src-gen/syntax/Signatures.sdf
+++ b/dynsem/src-gen/syntax/Signatures.sdf
@@ -1,4 +1,3 @@
-
 module Signatures
 imports Common ds
 
@@ -42,15 +41,6 @@ exports
     CONTENTCOMPLETE -> SemanticCompDecl {cons("COMPLETION-SemanticCompDecl")}
 
   context-free syntax
-    "internal-sorts" InternalSortDecl* -> SignatureSection {cons("InternalSorts")}
-    ID                                 -> InternalSortDecl {cons("InternalSortDecl")}
-    ID "->" ID                         -> InternalSortDecl {cons("InternalInjDecl")}
-
-  context-free syntax
-    CONTENTCOMPLETE -> SignatureSection {cons("COMPLETION-SignatureSection")}
-    CONTENTCOMPLETE -> InternalSortDecl {cons("COMPLETION-InternalSortDecl")}
-
-  context-free syntax
     "native-datatypes" NativeTypeDecl*                   -> SignatureSection   {cons("NativeDataTypes")}
     STRING                                               -> JSNIPPET           
     JSNIPPET "as" ID "{" NativeFunctionDecl* "}"         -> NativeTypeDecl     {cons("NativeBaseTypeDecl")}
@@ -74,15 +64,6 @@ exports
     CONTENTCOMPLETE -> NativeOpDecl     {cons("COMPLETION-NativeOpDecl")}
 
   context-free syntax
-    "internal-constructors" InternalConsDecl* -> SignatureSection {cons("InternalConstructors")}
-    ID ":" {Type "*"}+ "->" Type              -> InternalConsDecl {cons("InternalConsDecl")}
-    ID ":" Type                               -> InternalConsDecl {cons("NullaryInternalConsDecl")}
-
-  context-free syntax
-    CONTENTCOMPLETE -> SignatureSection {cons("COMPLETION-SignatureSection")}
-    CONTENTCOMPLETE -> InternalConsDecl {cons("COMPLETION-InternalConsDecl")}
-
-  context-free syntax
     "native-constructors" NativeConsDecl* -> SignatureSection {cons("NativeConstructors")}
     ID ":" {Type "*"}+ "->" Type          -> NativeConsDecl   {cons("NativeConsDecl")}
     ID ":" Type                           -> NativeConsDecl   {cons("NullaryNativeConsDecl")}
@@ -92,14 +73,11 @@ exports
     CONTENTCOMPLETE -> NativeConsDecl   {cons("COMPLETION-NativeConsDecl")}
 
   context-free syntax
-    "arrows" DeclaredArrow*                                -> SignatureSection         {cons("ArrowDeclarations")}
-    ArrowDeclaration                                       -> DeclaredArrow            
-    ArrowTemplateDeclaration                               -> DeclaredArrow            
-    Type "-" ID "->" Type                                  -> ArrowDeclaration         {cons("ArrowDecl")}
-    Type "-->" Type                                        -> ArrowDeclaration         {cons("DefaultArrowDecl")}
-    "forall" ID+ "," Type "-" ID "(" ID "->" ID ")->" Type -> ArrowTemplateDeclaration {cons("ArrowTemplDecl")}
+    "arrows" DeclaredArrow* -> SignatureSection {cons("ArrowDeclarations")}
+    ArrowDeclaration        -> DeclaredArrow    
+    Type "-" ID "->" Type   -> ArrowDeclaration {cons("ArrowDecl")}
+    Type "-->" Type         -> ArrowDeclaration {cons("DefaultArrowDecl")}
 
   context-free syntax
-    CONTENTCOMPLETE -> SignatureSection         {cons("COMPLETION-SignatureSection")}
-    CONTENTCOMPLETE -> ArrowDeclaration         {cons("COMPLETION-ArrowDeclaration")}
-    CONTENTCOMPLETE -> ArrowTemplateDeclaration {cons("COMPLETION-ArrowTemplateDeclaration")}
+    CONTENTCOMPLETE -> SignatureSection {cons("COMPLETION-SignatureSection")}
+    CONTENTCOMPLETE -> ArrowDeclaration {cons("COMPLETION-ArrowDeclaration")}

--- a/dynsem/syntax/Signatures.sdf3
+++ b/dynsem/syntax/Signatures.sdf3
@@ -26,7 +26,8 @@ context-free syntax // constructor declarations
     constructors
       <{ConsDecl "\n"}*>>
 
-  ConsDecl.ConsDecl = [[ID] : [{Type " * "}*] -> [Type]]
+  ConsDecl.ConsDecl = [[ID] : [{Type " * "}+] -> [Type]]
+  ConsDecl.NullaryConsDecl = [[ID] : [Type]]
 
   Type.SimpleSort = <<ID>>
   Type.ListSort = <List(<Type>)> 
@@ -81,7 +82,8 @@ context-free syntax // native operator declarations
     native-operators
       <{NativeOpDecl "\n"}*>>
   
-  NativeOpDecl.NativeOpDecl = [[ID] : [{Type " * "}*] -> [Type]]
+  NativeOpDecl.NativeOpDecl = [[ID] : [{Type " * "}+] -> [Type]]
+  NativeOpDecl.NullaryNativeOpDecl = [[ID] : [Type]]
 
 context-free syntax // internal constructor declarations
 
@@ -89,7 +91,8 @@ context-free syntax // internal constructor declarations
     internal-constructors
       <{InternalConsDecl "\n"}*>>
 
-  InternalConsDecl.InternalConsDecl = [[ID] : [{Type " * "}*] -> [Type]]
+  InternalConsDecl.InternalConsDecl = [[ID] : [{Type " * "}+] -> [Type]]
+  InternalConsDecl.NullaryInternalConsDecl = [[ID] : [Type]]
 
 context-free syntax // internal constructor declarations
 
@@ -97,7 +100,8 @@ context-free syntax // internal constructor declarations
     native-constructors
       <{NativeConsDecl "\n"}*>>
 
-  NativeConsDecl.NativeConsDecl = [[ID] : [{Type " * "}*] -> [Type]]
+  NativeConsDecl.NativeConsDecl = [[ID] : [{Type " * "}+] -> [Type]]
+  NativeConsDecl.NullaryNativeConsDecl = [[ID] : [Type]]
 
 context-free syntax
   

--- a/dynsem/syntax/Signatures.sdf3
+++ b/dynsem/syntax/Signatures.sdf3
@@ -47,15 +47,6 @@ context-free syntax // semantic component declarations
   
   SemanticCompDecl.SemanticComponent = [[ID] -> [MapType]]
 
-context-free syntax // internal sort declarations
-  
-  SignatureSection.InternalSorts = <
-    internal-sorts
-      <{InternalSortDecl "\n"}*>>
-  
-  InternalSortDecl.InternalSortDecl = <<ID>>
-  InternalSortDecl.InternalInjDecl = [[ID] -> [ID]]
-
 context-free syntax // native data types
 
   SignatureSection.NativeDataTypes = <
@@ -87,15 +78,6 @@ context-free syntax // native operator declarations
 
 context-free syntax // internal constructor declarations
 
-  SignatureSection.InternalConstructors = <
-    internal-constructors
-      <{InternalConsDecl "\n"}*>>
-
-  InternalConsDecl.InternalConsDecl = [[ID] : [{Type " * "}+] -> [Type]]
-  InternalConsDecl.NullaryInternalConsDecl = [[ID] : [Type]]
-
-context-free syntax // internal constructor declarations
-
   SignatureSection.NativeConstructors = <
     native-constructors
       <{NativeConsDecl "\n"}*>>
@@ -110,9 +92,6 @@ context-free syntax
       <{DeclaredArrow "\n"}*>>
   
   DeclaredArrow = ArrowDeclaration
-  DeclaredArrow = ArrowTemplateDeclaration
   
   ArrowDeclaration.ArrowDecl = [[Type] -[ID]-> [Type]]
   ArrowDeclaration.DefaultArrowDecl = [[Type] --> [Type]]
-
-  ArrowTemplateDeclaration.ArrowTemplDecl = [forall [{ID " "}+], [Type] -[ID]([ID] -> [ID])-> [Type]]

--- a/dynsem/trans/analysis/analysis-signatures.str
+++ b/dynsem/trans/analysis/analysis-signatures.str
@@ -24,7 +24,7 @@ rules /* store signatures */
     ; <store-def(|Types())> BoolType() => def-bool; <store-prop(|SortKind(), def-bool)> SystemSort()
     ; <store-def(|Types())> StringType() => def-str; <store-prop(|SortKind(), def-str)> SystemSort()
 
-  store-sorts = Sorts(map(store-sort)) + InternalSorts(map(store-sort))
+  store-sorts = Sorts(map(store-sort))
 
   store-sort:
     decl@SortDecl(ty) -> decl
@@ -40,23 +40,8 @@ rules /* store signatures */
       <store-prop(|SortKind(), ty-def)> LanguageSort();
       <store-prop(|SuperType(), ty-def)> sty
 
-  store-sort:
-    decl@InternalSortDecl(ty) -> decl
-    where
-      <store-def(|Types())> ty => ty-def;
-      <store-prop(|SortKind(), ty-def)> InternalSort()
-
-  store-sort:
-    decl@InternalInjDecl(ty, sty-name) -> decl
-    where
-      <id-to-type> sty-name => sty;
-      <store-def(|Types())> ty => ty-def;
-      <store-prop(|SortKind(), ty-def)> InternalSort();
-      <store-prop(|SuperType(), ty-def)> sty
-
   store-constructors =
     Constructors(map(store-constructor))
-    + InternalConstructors(map(store-constructor))
     + NativeConstructors(map(store-constructor))
   
   store-constructor:
@@ -65,13 +50,6 @@ rules /* store signatures */
       <store-def(|Constructors())> c => c-def;
       <store-prop(|Type(), c-def)> ConstructorType(<rw-type> child*, <rw-type> s);
       <store-prop(|ConsKind(), c-def)> LanguageCons()
-
-  store-constructor:
-    d@InternalConsDecl(c, child*, s) -> d
-    with
-      <store-def(|Constructors())> c => c-def;
-      <store-prop(|Type(), c-def)> ConstructorType(<rw-type> child*, <rw-type> s);
-      <store-prop(|ConsKind(), c-def)> InternalCons()
 
   store-constructor:
     d@NativeConsDecl(c, child*, s) -> d
@@ -136,7 +114,7 @@ rules
   check-signatures = alltd(check-signature)
   
   check-signature =
-    ( ?SimpleSort(s) + ?InjDecl(_, s) + ?InternalInjDecl(_, s) );
+    ( ?SimpleSort(s) + ?InjDecl(_, s) );
     <id-to-type; not(lookup-def(|Types()))> s;
     add-msg(|Error(), s, $[Sort [s] is not declared])
 
@@ -144,8 +122,6 @@ rules
     (
       ?SortDecl(s)
       + ?InjDecl(s, _)
-      + ?InternalSortDecl(s)
-      + ?InternalInjDecl(_, s)
       + ?NativeBaseTypeDecl(_, s, _)
       + ?NativeSubTypeDecl(_, s, _, _)
     );
@@ -161,7 +137,6 @@ rules
     (
       ?NativeOpDecl(c, _, _)
       + ?ConsDecl(c, _, _)
-      + ?InternalConsDecl(c, _, _)
       + ?NativeConsDecl(c, _, _)
     );
     <lookup-defs(|Constructors())> c => [_, _ | _];

--- a/dynsem/trans/analysis/constructors.str
+++ b/dynsem/trans/analysis/constructors.str
@@ -46,14 +46,12 @@ signature
   constructors
     SortKind: Property
     LanguageSort: SortKind
-  	InternalSort: SortKind
   	SemanticCompSort: SortKind
   	NativeSort: SortKind
   	SystemSort: SortKind
   	
   	ConsKind: Property
   	LanguageCons: ConsKind
-  	InternalCons: ConsKind
   	NativeCons: ConsKind
   	NativeOpCons: ConsKind
 

--- a/dynsem/trans/backend/java-backend/analysis-extra.str
+++ b/dynsem/trans/backend/java-backend/analysis-extra.str
@@ -58,7 +58,7 @@ rules
       <lookup-applicable-arrow-def> c-ty => arrow*
       
 
-  type-is-adoptable = where(lookup-def(|Types()); lookup-prop(|SortKind()); (?LanguageSort() + ?InternalSort()))
+  type-is-adoptable = where(lookup-def(|Types()); lookup-prop(|SortKind()) => LanguageSort())
 
   type-is-adoptable-list = where(?ListType(<id>); type-is-adoptable)
   

--- a/dynsem/trans/backend/java-backend/emit-atermconversion.str
+++ b/dynsem/trans/backend/java-backend/emit-atermconversion.str
@@ -77,7 +77,7 @@ rules
   	RealType() -> e |[ factory.makeReal(e) ]|
 
   ds2java-atermconversion-name(|e):
-  	BoolType() -> e |[ factory.makeAppl(factory.makeConstructor(e ? "True" : "False", 0)) ]|
+    BoolType() -> e |[ TermUtils.termFromBool(e, factory) ]|
   
   ds2java-atermconversion-name(|e):
   	StringType() -> e |[ factory.makeString(e) ]|

--- a/dynsem/trans/backend/java-backend/emit-genericnodes.str
+++ b/dynsem/trans/backend/java-backend/emit-genericnodes.str
@@ -116,6 +116,7 @@ rules
       ty-def := <lookup-def(|Types())> ty;
       <not(lookup-prop(|SortKind()) => SystemSort())> ty-def;
       <not(lookup-prop(|SortKind()) => SemanticCompSort())> ty-def;
+      <not(lookup-prop(|SortKind()) => NativeSort())> ty-def;
       gennodename := $[Generic_[<ds2java-sort-classname> ty]]
 
   ds2java-gennode-instantiation:
@@ -130,6 +131,12 @@ rules
       <lookup-prop(|SortKind())> ty-def => SemanticCompSort();
       ty-name := <def-get-name> ty-def;
       x_tosemcomp := <ds2java-aterm2map-name> ty-name
+ 
+  ds2java-gennode-instantiation:
+  	(e_trm, ty) -> e |[ null ]|
+  	where
+  		ty-def := <lookup-def(|Types())> ty;
+  		<lookup-prop(|SortKind())> ty-def => NativeSort()
  
   ds2java-gennode-instantiation:
     (e_trm, StringType()) -> e |[ Tools.asJavaString(e_trm) ]|

--- a/dynsem/trans/backend/java-backend/emit-genericnodes.str
+++ b/dynsem/trans/backend/java-backend/emit-genericnodes.str
@@ -13,6 +13,7 @@ imports
   backend/java-backend/analysis-extra
   backend/java-backend/lib-ds2java
   backend/java-backend/emit-arrows
+  backend/java-backend/emit-maputils
 
 rules
   
@@ -108,11 +109,14 @@ rules
       debug(!14);
       consname := <ds2java-constr-classname> c-name;
       debug(!15);
-      e* := <map-with-index((dec, id); ds2java-gennode-instantiation)> c-c-ty*
+      e* := <map-with-index((\ idx -> e |[ term.getSubterm(~i:<int-to-string> idx)]| \, id); ds2java-gennode-instantiation)> c-c-ty*
       ;debug(!16)
-      
+  
+  subterm-at-index:
+    idx -> e |[ term.getSubterm(~i:<int-to-string> idx) ]|
+
   ds2java-gennode-instantiation:
-    (idx, ty) -> e |[ new ~x:gennodename(source, term.getSubterm(~i:<int-to-string> idx)) ]|
+    (e_trm, ty) -> e |[ new ~x:gennodename(NodeSource.fromStrategoTerm(e_trm), e_trm) ]|
     where
       not(!ty => ListType(_));
       ty-def := <lookup-def(|Types())> ty;
@@ -121,32 +125,30 @@ rules
       gennodename := $[Generic_[<ds2java-sort-classname> ty]]
 
   ds2java-gennode-instantiation:
-    (idx, lty@ListType(e-ty)) -> e |[ new x_listname(NodeSource.fromStrategoTerm(term.getSubterm(i))).fromStrategoTerm(term.getSubterm(i)) ]|
+    (e_trm, lty@ListType(e-ty)) -> e |[ new x_listname(NodeSource.fromStrategoTerm(e_trm)).fromStrategoTerm(e_trm) ]|
     where
-      i := <int-to-string> idx;
       x_listname := <ds2java-sort-classname> lty
+  
+  ds2java-gennode-instantiation:
+    (e_trm, ty) -> e |[ AutoMapUtils.x_tosemcomp(e_trm) ]|
+    where
+      ty-def := <lookup-def(|Types())> ty;
+      <lookup-prop(|SortKind())> ty-def => SemanticCompSort();
+      ty-name := <def-get-name> ty-def;
+      x_tosemcomp := <ds2java-aterm2map-name> ty-name
  
   ds2java-gennode-instantiation:
-    (idx, ty) -> e |[ new x_listname(NodeSource.fromStrategoTerm(term.getSubterm(i))).fromStrategoTerm(term.getSubterm(i)) ]|
-    where
-      i := <int-to-string> idx;
-      ty-def := <lookup-def(|Types())> ty;
-      <not(lookup-prop(|SortKind()) => SemanticCompSort())> ty-def
+    (e_trm, StringType()) -> e |[ Tools.asJavaString(e_trm) ]|
 
   ds2java-gennode-instantiation:
-    (idx, StringType()) -> e |[ Tools.asJavaString(term.getSubterm(~i:<int-to-string> idx)) ]|
+    (e_trm, IntType()) -> e |[ Tools.asJavaInt(e_trm) ]|
 
   ds2java-gennode-instantiation:
-    (idx, IntType()) -> e |[ Tools.asJavaInt(term.getSubterm(~i:<int-to-string> idx)) ]|
-
+    (e_trm, RealType()) -> e |[ Tools.asJavaDouble(e_trm) ]|
+  
+  // TODO
   ds2java-gennode-instantiation:
-    (idx, RealType()) -> e |[ Tools.asJavaDouble(term.getSubterm(~i:<int-to-string> idx)) ]|
-
-  ds2java-gennode-instantiation:
-    (idx, BoolType()) -> e |[ false ]| // TODO: maybe there is some actual conversion convention we could use
-
-  // ds2java-gennode-instantiation:
-  // 
+    (e_trm, BoolType()) -> e |[ 55 ]| // TODO: maybe there is some actual conversion convention we could use
 
   ds2java-sortinj-specializer:
   	(ty-def, bstm*) ->

--- a/dynsem/trans/backend/java-backend/emit-genericnodes.str
+++ b/dynsem/trans/backend/java-backend/emit-genericnodes.str
@@ -18,7 +18,7 @@ imports
 rules
   
   ds2java-genericnodes:
-    Module(_, _) -> <map(debug(!"A "); def-get-name; debug(!"B "); ds2java-genericnode; debug(!"C "))> def-ty* 
+    Module(_, _) -> <map(def-get-name; ds2java-genericnode)> def-ty* 
     where
       def-ty* := <lookup-def-all(|Types()); filter(where(lookup-prop(|SortKind()) => LanguageSort()))>
 
@@ -100,17 +100,11 @@ rules
 		    }
 			]|
     where
-      debug(!11);
       c-name := <def-get-name> c-def;
-      debug(!12);
       ConstructorType(c-c-ty*, c-ty) := <lookup-prop(|Type())> c-def;
-      debug(!13);
       sortname := <ds2java-sort-classname> c-ty;
-      debug(!14);
       consname := <ds2java-constr-classname> c-name;
-      debug(!15);
       e* := <map-with-index((\ idx -> e |[ term.getSubterm(~i:<int-to-string> idx)]| \, id); ds2java-gennode-instantiation)> c-c-ty*
-      ;debug(!16)
   
   subterm-at-index:
     idx -> e |[ term.getSubterm(~i:<int-to-string> idx) ]|

--- a/dynsem/trans/backend/java-backend/emit-genericnodes.str
+++ b/dynsem/trans/backend/java-backend/emit-genericnodes.str
@@ -62,11 +62,11 @@ rules
               final String name = term.getName();
               final INodeSource source = NodeSource.fromStrategoTerm(term);
 
-              ~bstm*:<mapconcat(debug(!1); ds2java-consdecl-specializer; debug(!2))> c-def*
+              ~bstm*:<mapconcat(ds2java-consdecl-specializer)> c-def*
             }
             IGenericNode replacement = null;
             
-            ~bstm*:<foldr(![], debug(!3); ds2java-sortinj-specializer; debug(!4))> ty-def*
+            ~bstm*:<foldr(![], ds2java-sortinj-specializer)> ty-def*
             
             throw new RewritingException(aterm.toString());
             
@@ -140,9 +140,8 @@ rules
   ds2java-gennode-instantiation:
     (e_trm, RealType()) -> e |[ Tools.asJavaDouble(e_trm) ]|
   
-  // TODO
   ds2java-gennode-instantiation:
-    (e_trm, BoolType()) -> e |[ 55 ]| // TODO: maybe there is some actual conversion convention we could use
+    (e_trm, BoolType()) -> e |[ TermUtils.boolFromTerm(e_trm) ]|
 
   ds2java-sortinj-specializer:
   	(ty-def, bstm*) ->

--- a/dynsem/trans/backend/java-backend/emit-genericnodes.str
+++ b/dynsem/trans/backend/java-backend/emit-genericnodes.str
@@ -17,7 +17,7 @@ imports
 rules
   
   ds2java-genericnodes:
-    Module(_, _) -> <map(def-get-name; ds2java-genericnode)> def-ty* 
+    Module(_, _) -> <map(debug(!"A "); def-get-name; debug(!"B "); ds2java-genericnode; debug(!"C "))> def-ty* 
     where
       def-ty* := <lookup-def-all(|Types()); filter(where(lookup-prop(|SortKind()) => LanguageSort()))>
 
@@ -61,11 +61,11 @@ rules
               final String name = term.getName();
               final INodeSource source = NodeSource.fromStrategoTerm(term);
 
-              ~bstm*:<mapconcat(ds2java-consdecl-specializer)> c-def*
+              ~bstm*:<mapconcat(debug(!1); ds2java-consdecl-specializer; debug(!2))> c-def*
             }
             IGenericNode replacement = null;
             
-            ~bstm*:<foldr(![], ds2java-sortinj-specializer)> ty-def*
+            ~bstm*:<foldr(![], debug(!3); ds2java-sortinj-specializer; debug(!4))> ty-def*
             
             throw new RewritingException(aterm.toString());
             
@@ -99,11 +99,17 @@ rules
 		    }
 			]|
     where
+      debug(!11);
       c-name := <def-get-name> c-def;
+      debug(!12);
       ConstructorType(c-c-ty*, c-ty) := <lookup-prop(|Type())> c-def;
+      debug(!13);
       sortname := <ds2java-sort-classname> c-ty;
+      debug(!14);
       consname := <ds2java-constr-classname> c-name;
+      debug(!15);
       e* := <map-with-index((dec, id); ds2java-gennode-instantiation)> c-c-ty*
+      ;debug(!16)
       
   ds2java-gennode-instantiation:
     (idx, ty) -> e |[ new ~x:gennodename(source, term.getSubterm(~i:<int-to-string> idx)) ]|
@@ -111,6 +117,7 @@ rules
       not(!ty => ListType(_));
       ty-def := <lookup-def(|Types())> ty;
       <not(lookup-prop(|SortKind()) => SystemSort())> ty-def;
+      <not(lookup-prop(|SortKind()) => SemanticCompSort())> ty-def;
       gennodename := $[Generic_[<ds2java-sort-classname> ty]]
 
   ds2java-gennode-instantiation:
@@ -118,6 +125,13 @@ rules
     where
       i := <int-to-string> idx;
       x_listname := <ds2java-sort-classname> lty
+ 
+  ds2java-gennode-instantiation:
+    (idx, ty) -> e |[ new x_listname(NodeSource.fromStrategoTerm(term.getSubterm(i))).fromStrategoTerm(term.getSubterm(i)) ]|
+    where
+      i := <int-to-string> idx;
+      ty-def := <lookup-def(|Types())> ty;
+      <not(lookup-prop(|SortKind()) => SemanticCompSort())> ty-def
 
   ds2java-gennode-instantiation:
     (idx, StringType()) -> e |[ Tools.asJavaString(term.getSubterm(~i:<int-to-string> idx)) ]|
@@ -127,6 +141,12 @@ rules
 
   ds2java-gennode-instantiation:
     (idx, RealType()) -> e |[ Tools.asJavaDouble(term.getSubterm(~i:<int-to-string> idx)) ]|
+
+  ds2java-gennode-instantiation:
+    (idx, BoolType()) -> e |[ false ]| // TODO: maybe there is some actual conversion convention we could use
+
+  // ds2java-gennode-instantiation:
+  // 
 
   ds2java-sortinj-specializer:
   	(ty-def, bstm*) ->

--- a/dynsem/trans/backend/java-backend/emit-maputils.str
+++ b/dynsem/trans/backend/java-backend/emit-maputils.str
@@ -12,6 +12,7 @@ imports
 	backend/java-backend/utils
 	backend/java-backend/lib-ds2java
 	backend/java-backend/emit-atermconversion
+	backend/java-backend/emit-genericnodes
 	
 rules
   
@@ -26,22 +27,26 @@ rules
       compilation-unit |[
         package ~x:<AutoPackageName>;
         
+        import java.util.Map;
         import java.util.Map.Entry;
+				import java.util.TreeMap;
         import org.spoofax.interpreter.terms.*;
+        import org.spoofax.interpreter.core.Tools;
         import org.metaborg.meta.interpreter.framework.*;
         import com.github.krukow.clj_ds.PersistentMap;
+        import com.github.krukow.clj_lang.PersistentTreeMap;
         
         public class AutoMapUtils {
           ~conv*
         }
       ]|
     where
-      conv* := <map(ds2java-maputils-semcomp)> semcomp-def*
+      conv* := <mapconcat(ds2java-maputils-semcomp)> semcomp-def*
   
   ds2java-maputils-semcomp:
     semcomp-def ->
-      class-body-dec |[
-        public static IStrategoTerm x_methodname(PersistentMap<x_kty, x_vty> map, ITermFactory factory) {
+      class-body-dec* |[
+        public static IStrategoTerm x_toterm(PersistentMap<x_kty, x_vty> map, ITermFactory factory) {
           IStrategoConstructor bindCons = factory.makeConstructor("Bind", 2);
 
           IStrategoTerm[] kids = new IStrategoTerm[map.size() + 1];
@@ -56,15 +61,48 @@ rules
           
           return factory.makeAppl(factory.makeConstructor("Map", 2), kids);
         }
+        
+        public static PersistentMap<x_kty, x_vty> x_fromterm(IStrategoTerm term) {
+          final String mapName = ~e:Lit(String([Chars(semcomp-name)]));
+			    final Map<x_kty, x_vty> result = new TreeMap<x_kty, x_vty>();
+			    if (Tools.isTermAppl(term)) {
+			      IStrategoAppl appl = (IStrategoAppl) term;
+			      if (Tools.hasConstructor(appl, "Map", 2)) {
+			        IStrategoTerm kid0 = term.getSubterm(0);
+			        if (Tools.isTermString(kid0)
+			            && Tools.asJavaString(kid0).equals(mapName)) {
+			          for (int idx = 1; idx < term.getSubtermCount(); idx++) {
+			            IStrategoTerm kid = term.getSubterm(idx);
+			            if (Tools.isTermAppl(kid)) {
+			              IStrategoAppl bindAppl = (IStrategoAppl) kid;
+			              if (Tools.hasConstructor(bindAppl, "Bind", 2)) {
+			                result.put(e_key, e_value);
+			              }
+			            }
+			          }
+			          return PersistentTreeMap.create(result);
+			        }
+			
+			      }
+			    }
+			
+			    throw new RuntimeException("Malformed map for " + mapName);
+			  }
       ]|
     where
       semcomp-name := <def-get-name> semcomp-def;
-      x_methodname := <ds2java-map2aterm-name> semcomp-name;
+      x_toterm := <ds2java-map2aterm-name> semcomp-name;
+      x_fromterm := <ds2java-aterm2map-name> semcomp-name;
       MapType(k-ty, v-ty) := <lookup-prop(|SuperType())> semcomp-def;
       x_kty := <ds2java-sort-classname; ds2java-box-java-type> k-ty;
       x_vty := <ds2java-sort-classname; ds2java-box-java-type> v-ty;
       e_keytrm := <ds2java-atermconversion-name(| e |[ entry.getKey() ]|)> k-ty;
-      e_valtrm := <ds2java-atermconversion-name(| e |[ entry.getValue() ]|)> v-ty
+      e_valtrm := <ds2java-atermconversion-name(| e |[ entry.getValue() ]|)> v-ty;
+      e_key := <ds2java-gennode-instantiation> (e |[ bindAppl.getSubterm(0) ]|, k-ty);
+      e_value := <ds2java-gennode-instantiation> (e |[ bindAppl.getSubterm(1) ]|, v-ty)
 
   ds2java-map2aterm-name:
   	semcomp-name -> $[toStrategoTerm_[semcomp-name]]
+
+  ds2java-aterm2map-name:
+  	semcomp-name -> $[to_[semcomp-name]]

--- a/dynsem/trans/backend/java-backend/emit-types.str
+++ b/dynsem/trans/backend/java-backend/emit-types.str
@@ -19,7 +19,7 @@ rules /* generate interfaces for sort declarations */
     Module(_, section*) -> iface*
     where
       all-type-def*  := <lookup-def-all(|Types())>;
-      type-def* := <filter(where(lookup-prop(|SortKind()); (?LanguageSort() + ?InternalSort())))> all-type-def*;
+      type-def* := <filter(where(lookup-prop(|SortKind()) => LanguageSort()))> all-type-def*;
       iface* := <map(?(_, <id>); ds2java-interface)> type-def*
   
   ds2java-interface:

--- a/dynsem/trans/ds2ds/fuse-sections.str
+++ b/dynsem/trans/ds2ds/fuse-sections.str
@@ -11,14 +11,12 @@ rules
       import       := <collect-all(?Imports(<id>)); concat; !Imports(<id>)> body*;
       sort-decl    := <collect-all(?Sorts(<id>)); concat; !Sorts(<id>)> body*;
       semcomp-decl := <collect-all(?SemanticComponents(<id>)); concat; !SemanticComponents(<id>)> body*;
-      intsort-decl := <collect-all(?InternalSorts(<id>)); concat; !InternalSorts(<id>)> body*;
       natty-decl   := <collect-all(?NativeDataTypes(<id>)); concat; !NativeDataTypes(<id>)> body*;
       cons-decl    := <collect-all(?Constructors(<id>)); concat; !Constructors(<id>)> body*;
-      intcons-decl := <collect-all(?InternalConstructors(<id>)); concat; !InternalConstructors(<id>)> body*;
       natcons-decl := <collect-all(?NativeConstructors(<id>)); concat; !NativeConstructors(<id>)> body*;
       natops-decl  := <collect-all(?NativeOperators(<id>)); concat; !NativeOperators(<id>)> body*;
       arrow-decl   := <collect-all(?ArrowDeclarations(<id>)); concat; !ArrowDeclarations(<id>)> body*;
-      signatures    := [ sort-decl, intsort-decl, cons-decl, semcomp-decl, intcons-decl, natcons-decl, natops-decl, arrow-decl, natty-decl ];
+      signatures    := [ sort-decl, cons-decl, semcomp-decl, natcons-decl, natops-decl, arrow-decl, natty-decl ];
       rule-decl*    := <collect-all(?Rules(<id>)); concat; sort-rules> body*
   
   sort-rules = qsort((rule-con-name, rule-con-name); string-gt)

--- a/dynsem/trans/ds2ds/merge-rules.str
+++ b/dynsem/trans/ds2ds/merge-rules.str
@@ -30,7 +30,7 @@ rules /* merge ovelapping rules */
   merge-rules-in-module:
     Module(name, [imports, signatures, Rules(rule*)]) -> Module($[[name]_unified], [imports, signatures, Rules([merged-rule*, rule'*])])
     with
-      cons-arity* := <collect-all(cons-decl-pair-arity); make-set> signatures;
+      cons-arity* := <collect-all(\ ConsDecl(cons, args, _) -> (cons, <length> args) \); make-set> signatures;
       arrow-name* := <get-module-arrow-declarations; map(get-arrow-name); make-set> signatures;
       rules-by-cons* := <map(group-rules-by-cons(|rule*))> cons-arity*;
       rule'* := <diff> (rule*, <mapconcat(?(_, _, <id>))> rules-by-cons*); // rules not covered by cons-merging
@@ -53,12 +53,6 @@ rules /* merge ovelapping rules */
       rule'* := <filter(not(?[])); map(unmark-vars; map(remove-aliases; rename-components; rename-output))> rules-by-type-by-arrow*;
       rule''* := <mapconcat(merge-rules-top)> rule'*      
       
-  cons-decl-pair-arity:
-    ConsDecl(cons, args, _) -> (cons, <length> args)
-  
-  cons-decl-pair-arity:
-    InternalConsDecl(cons, args, _) -> (cons, <length> args)
-
   group-rules-by-cons(|rule*):
     (cons, arity) -> (cons, arity, rulez)
     with

--- a/dynsem/trans/ds2ds/sugar.str
+++ b/dynsem/trans/ds2ds/sugar.str
@@ -17,6 +17,18 @@ rules // desugaring
     NativeNoArgFunctionDecl(name, type) -> NativeFunctionDecl(name, [], type)
   
   desugar :
+    NullaryConsDecl(c, s) -> ConsDecl(c, [], s)
+  
+  desugar :
+    NullaryInternalConsDecl(c, s) -> InternalConsDecl(c, [], s)
+
+  desugar :
+    NullaryNativeConsDecl(c, s) -> NativeConsDecl(c, [], s)
+
+  desugar :
+    NullaryNativeOpDecl(c, s) -> NativeOpDecl(c, [], s)
+  
+  desugar :
     RuleW(form, prem*) -> Rule(prem*, "---", form)
   
   desugar :
@@ -83,6 +95,18 @@ rules // sugaring
   
   sugar :
     NativeFunctionDecl(name, [], type) -> NativeNoArgFunctionDecl(name, type)
+  
+  sugar :
+    ConsDecl(c, [], s) -> NullaryConsDecl(c, s)
+  
+  sugar :
+    InternalConsDecl(c, [], s) -> NullaryInternalConsDecl(c, s)
+
+  sugar :
+    NativeConsDecl(c, [], s) -> NullaryNativeConsDecl(c, s)
+
+  sugar :
+    NativeOpDecl(c, [], s) -> NullaryNativeOpDecl(c, s)
   
   sugar :
   	Rule([],infer,conc) -> Axiom(conc)

--- a/dynsem/trans/ds2ds/sugar.str
+++ b/dynsem/trans/ds2ds/sugar.str
@@ -20,9 +20,6 @@ rules // desugaring
     NullaryConsDecl(c, s) -> ConsDecl(c, [], s)
   
   desugar :
-    NullaryInternalConsDecl(c, s) -> InternalConsDecl(c, [], s)
-
-  desugar :
     NullaryNativeConsDecl(c, s) -> NativeConsDecl(c, [], s)
 
   desugar :
@@ -99,9 +96,6 @@ rules // sugaring
   sugar :
     ConsDecl(c, [], s) -> NullaryConsDecl(c, s)
   
-  sugar :
-    InternalConsDecl(c, [], s) -> NullaryInternalConsDecl(c, s)
-
   sugar :
     NativeConsDecl(c, [], s) -> NullaryNativeConsDecl(c, s)
 

--- a/dynsem/trans/lib-ds.str
+++ b/dynsem/trans/lib-ds.str
@@ -15,7 +15,7 @@ rules // utils for deterministic variable name generation
 
 rules // projections for sorts
   
-  get-sort-name = ?SortDecl(<id>) + ?InjDecl(<id>, _) + ?SemanticComponent(<id>, _) + ?InternalSortDecl(<id>)
+  get-sort-name = ?SortDecl(<id>) + ?InjDecl(<id>, _) + ?SemanticComponent(<id>, _)
   get-sort-name = ?SimpleSort(<id>) + ?ListSort(s); !$[L_[<get-sort-name> s]]
   
   get-listsort-elementname = ?ListSort(<get-sort-name>)

--- a/org.metaborg.meta.interpreter.framework/pom.xml
+++ b/org.metaborg.meta.interpreter.framework/pom.xml
@@ -26,6 +26,11 @@
 			<artifactId>org.spoofax.terms</artifactId>
 			<version>${metaborg-version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.metaborg</groupId>
+			<artifactId>org.spoofax.interpreter.core</artifactId>
+			<version>${metaborg-version}</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/org.metaborg.meta.interpreter.framework/src/org/metaborg/meta/interpreter/framework/TermUtils.java
+++ b/org.metaborg.meta.interpreter.framework/src/org/metaborg/meta/interpreter/framework/TermUtils.java
@@ -1,0 +1,26 @@
+package org.metaborg.meta.interpreter.framework;
+
+import org.spoofax.interpreter.core.Tools;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermFactory;
+
+public class TermUtils {
+
+	public static boolean boolFromTerm(IStrategoTerm term) {
+		if (Tools.isTermAppl(term)) {
+			IStrategoAppl tAppl = (IStrategoAppl) term;
+			if (Tools.hasConstructor(tAppl, "$__DS_False__$", 0)) {
+				return false;
+			} else if (Tools.hasConstructor(tAppl, "$__DS_True__$", 0)) {
+				return true;
+			}
+		}
+		throw new RuntimeException("Malformed boolean: " + term);
+	}
+
+	public static IStrategoTerm termFromBool(boolean bV, ITermFactory factory) {
+		return factory.makeAppl(factory.makeConstructor(bV ? "$__DS_True__$"
+				: "$__DS_False__$", 0));
+	}
+}


### PR DESCRIPTION
Improves syntax by dropping the compulsory `->` in constructor declarations. Drops support for `internal-sorts` and `internal-constructors` and implements aterm-to-node and node-to-aterm conversions.
