### PR TITLE
Sort aliases instead of semantic components

### DIFF
--- a/dynsem/editor/ds-Menus.esv
+++ b/dynsem/editor/ds-Menus.esv
@@ -39,6 +39,7 @@ menus
     action  : "Unstrictify"            = unstrict-editor (openeditor) (realtime)
     action  : "Refocus"                = refocus-editor (openeditor) (realtime)
     action  : "Add type annotations"   = add-extra-typeannos-editor (openeditor) (realtime)
+    action  : "Desugar aliases"        = desugar-aliases-editor (openeditor) (realtime)
     action  : "Desugar varschemes"     = desugar-varschemes-editor (openeditor) (realtime) (source)
     action  : "Factorize"              = factorize-editor (openeditor) (realtime) (source)
     action  : "Expand implicits"       = expand-implicits-editor (openeditor) (realtime) (source)

--- a/dynsem/src-gen/check/Signatures-chk.str
+++ b/dynsem/src-gen/check/Signatures-chk.str
@@ -124,6 +124,47 @@ strategies
     check-SignatureSection
 
   check-example =
+    check-AliasDecl
+
+  check-SignatureSection :
+    Aliases(t1__) -> <id>
+    with <map(check-AliasDecl <+ error-AliasDecl)> t1__
+
+  is-SignatureSection-with-constructor =
+    ?Aliases(_)
+
+  check-AliasDecl :
+    AliasDecl(t1__, t2__) -> <id>
+    with <(check-ID <+ error-ID)> t1__
+    with <(check-Type <+ error-Type)> t2__
+
+  is-AliasDecl-with-constructor =
+    ?AliasDecl(_, _)
+
+  is-SignatureSection-with-constructor =
+    fail
+
+  is-AliasDecl-with-constructor =
+    fail
+
+  check-SignatureSection :
+    amb([h|hs]) -> <check-SignatureSection> h
+
+  check-AliasDecl :
+    amb([h|hs]) -> <check-AliasDecl> h
+
+  error-SignatureSection =
+    debug(!"Unexpected constructor. Expected constructor from sort SignatureSection instead. ")
+
+  error-AliasDecl =
+    debug(!"Unexpected constructor. Expected constructor from sort AliasDecl instead. ")
+
+
+strategies
+  check-example =
+    check-SignatureSection
+
+  check-example =
     check-ConsAnnos
 
   check-example =

--- a/dynsem/src-gen/check/Signatures-chk.str
+++ b/dynsem/src-gen/check/Signatures-chk.str
@@ -279,47 +279,6 @@ strategies
     check-SignatureSection
 
   check-example =
-    check-SemanticCompDecl
-
-  check-SignatureSection :
-    SemanticComponents(t1__) -> <id>
-    with <map(check-SemanticCompDecl <+ error-SemanticCompDecl)> t1__
-
-  is-SignatureSection-with-constructor =
-    ?SemanticComponents(_)
-
-  check-SemanticCompDecl :
-    SemanticComponent(t1__, t2__) -> <id>
-    with <(check-ID <+ error-ID)> t1__
-    with <(check-MapType <+ error-MapType)> t2__
-
-  is-SemanticCompDecl-with-constructor =
-    ?SemanticComponent(_, _)
-
-  is-SignatureSection-with-constructor =
-    fail
-
-  is-SemanticCompDecl-with-constructor =
-    fail
-
-  check-SignatureSection :
-    amb([h|hs]) -> <check-SignatureSection> h
-
-  check-SemanticCompDecl :
-    amb([h|hs]) -> <check-SemanticCompDecl> h
-
-  error-SignatureSection =
-    debug(!"Unexpected constructor. Expected constructor from sort SignatureSection instead. ")
-
-  error-SemanticCompDecl =
-    debug(!"Unexpected constructor. Expected constructor from sort SemanticCompDecl instead. ")
-
-
-strategies
-  check-example =
-    check-SignatureSection
-
-  check-example =
     check-JSNIPPET
 
   check-example =

--- a/dynsem/src-gen/completions/Signatures-esv.esv
+++ b/dynsem/src-gen/completions/Signatures-esv.esv
@@ -37,12 +37,6 @@ completions
     "Map<" <Type:Type> "," <Type:Type> ">"  
 
 completions
-  completion template SignatureSection : "semantic components " =
-    "semantic components\n\t" (cursor) (blank)  
-  completion template SemanticCompDecl : "ID -> MapType" =
-    <ID:ID> " -> " <MapType:MapType>  
-
-completions
   completion template SignatureSection : "native datatypes " =
     "native datatypes\n\t" (cursor) (blank)  
   completion template NativeTypeDecl : "JSNIPPET as ID { } " =

--- a/dynsem/src-gen/completions/Signatures-esv.esv
+++ b/dynsem/src-gen/completions/Signatures-esv.esv
@@ -19,6 +19,12 @@ completions
     <ID:ID> " : " <Type:Type>  
 
 completions
+  completion template SignatureSection : "aliases " =
+    "aliases\n\t" (cursor) (blank)  
+  completion template AliasDecl : "ID : Type" =
+    <ID:ID> " : " <Type:Type>  
+
+completions
   completion template SignatureSection : "constructors " =
     "constructors\n\t" (cursor) (blank)  
   completion template ConsDecl : "ID : Type ConsAnnos" =

--- a/dynsem/src-gen/pp/Signatures-pp.str
+++ b/dynsem/src-gen/pp/Signatures-pp.str
@@ -342,50 +342,6 @@ strategies
     prettyprint-SignatureSection
 
   prettyprint-example =
-    prettyprint-SemanticCompDecl
-
-  prettyprint-SignatureSection :
-    SemanticComponents(t1__) -> [ H(
-                                    [SOpt(HS(), "0")]
-                                  , [S("semantic components")]
-                                  )
-                                , t1__'
-                                ]
-    with t1__' := <pp-indent(|"2")> [<pp-V-list(prettyprint-SemanticCompDecl)> t1__]
-
-  is-SignatureSection =
-    ?SemanticComponents(_)
-
-  prettyprint-SemanticCompDecl :
-    SemanticComponent(t1__, t2__) -> [ H(
-                                         [SOpt(HS(), "0")]
-                                       , [t1__', S(" -> "), t2__']
-                                       )
-                                     ]
-    with t1__' := <pp-one-Z(prettyprint-ID)> t1__
-    with t2__' := <pp-one-Z(prettyprint-MapType)> t2__
-
-  is-SemanticCompDecl =
-    ?SemanticComponent(_, _)
-
-  is-SignatureSection =
-    fail
-
-  is-SemanticCompDecl =
-    fail
-
-  prettyprint-SignatureSection :
-    amb([h|hs]) -> <prettyprint-SignatureSection> h
-
-  prettyprint-SemanticCompDecl :
-    amb([h|hs]) -> <prettyprint-SemanticCompDecl> h
-
-
-strategies
-  prettyprint-example =
-    prettyprint-SignatureSection
-
-  prettyprint-example =
     prettyprint-JSNIPPET
 
   prettyprint-example =

--- a/dynsem/src-gen/pp/Signatures-pp.str
+++ b/dynsem/src-gen/pp/Signatures-pp.str
@@ -132,6 +132,50 @@ strategies
     prettyprint-SignatureSection
 
   prettyprint-example =
+    prettyprint-AliasDecl
+
+  prettyprint-SignatureSection :
+    Aliases(t1__) -> [ H(
+                         [SOpt(HS(), "0")]
+                       , [S("aliases")]
+                       )
+                     , t1__'
+                     ]
+    with t1__' := <pp-indent(|"2")> [<pp-V-list(prettyprint-AliasDecl)> t1__]
+
+  is-SignatureSection =
+    ?Aliases(_)
+
+  prettyprint-AliasDecl :
+    AliasDecl(t1__, t2__) -> [ H(
+                                 [SOpt(HS(), "0")]
+                               , [t1__', S(" : "), t2__']
+                               )
+                             ]
+    with t1__' := <pp-one-Z(prettyprint-ID)> t1__
+    with t2__' := <pp-one-Z(prettyprint-Type)> t2__
+
+  is-AliasDecl =
+    ?AliasDecl(_, _)
+
+  is-SignatureSection =
+    fail
+
+  is-AliasDecl =
+    fail
+
+  prettyprint-SignatureSection :
+    amb([h|hs]) -> <prettyprint-SignatureSection> h
+
+  prettyprint-AliasDecl :
+    amb([h|hs]) -> <prettyprint-AliasDecl> h
+
+
+strategies
+  prettyprint-example =
+    prettyprint-SignatureSection
+
+  prettyprint-example =
     prettyprint-ConsAnnos
 
   prettyprint-example =

--- a/dynsem/src-gen/signatures/Signatures-sig.str
+++ b/dynsem/src-gen/signatures/Signatures-sig.str
@@ -31,10 +31,6 @@ signature
     MapSort         : Type * Type -> MapType
 
   constructors
-    SemanticComponents : List(SemanticCompDecl) -> SignatureSection
-    SemanticComponent  : ID * MapType -> SemanticCompDecl
-
-  constructors
     NativeDataTypes         : List(NativeTypeDecl) -> SignatureSection
                             : STRING -> JSNIPPET
     NativeBaseTypeDecl      : JSNIPPET * ID * List(NativeFunctionDecl) -> NativeTypeDecl

--- a/dynsem/src-gen/signatures/Signatures-sig.str
+++ b/dynsem/src-gen/signatures/Signatures-sig.str
@@ -18,6 +18,10 @@ signature
     VariableScheme  : ID * Type -> VariableScheme
 
   constructors
+    Aliases   : List(AliasDecl) -> SignatureSection
+    AliasDecl : ID * Type -> AliasDecl
+
+  constructors
     Constructors    : List(ConsDecl) -> SignatureSection
     NullaryConsDecl : ID * Type * ConsAnnos -> ConsDecl
     ConsDecl        : ID * List(Type) * Type * ConsAnnos -> ConsDecl

--- a/dynsem/src-gen/syntax/Signatures.sdf
+++ b/dynsem/src-gen/syntax/Signatures.sdf
@@ -25,6 +25,14 @@ exports
     CONTENTCOMPLETE -> VariableScheme   {cons("COMPLETION-VariableScheme")}
 
   context-free syntax
+    "aliases" AliasDecl* -> SignatureSection {cons("Aliases")}
+    ID ":" Type          -> AliasDecl        {cons("AliasDecl")}
+
+  context-free syntax
+    CONTENTCOMPLETE -> SignatureSection {cons("COMPLETION-SignatureSection")}
+    CONTENTCOMPLETE -> AliasDecl        {cons("COMPLETION-AliasDecl")}
+
+  context-free syntax
     "constructors" ConsDecl*               -> SignatureSection {cons("Constructors")}
     ID ":" Type ConsAnnos                  -> ConsDecl         {cons("NullaryConsDecl")}
     ID ":" {Type "*"}+ "->" Type ConsAnnos -> ConsDecl         {cons("ConsDecl")}

--- a/dynsem/src-gen/syntax/Signatures.sdf
+++ b/dynsem/src-gen/syntax/Signatures.sdf
@@ -46,14 +46,6 @@ exports
     CONTENTCOMPLETE -> MapType          {cons("COMPLETION-MapType")}
 
   context-free syntax
-    "semantic" "components" SemanticCompDecl* -> SignatureSection {cons("SemanticComponents")}
-    ID "->" MapType                           -> SemanticCompDecl {cons("SemanticComponent")}
-
-  context-free syntax
-    CONTENTCOMPLETE -> SignatureSection {cons("COMPLETION-SignatureSection")}
-    CONTENTCOMPLETE -> SemanticCompDecl {cons("COMPLETION-SemanticCompDecl")}
-
-  context-free syntax
     "native" "datatypes" NativeTypeDecl*                 -> SignatureSection   {cons("NativeDataTypes")}
     STRING                                               -> JSNIPPET           
     JSNIPPET "as" ID "{" NativeFunctionDecl* "}"         -> NativeTypeDecl     {cons("NativeBaseTypeDecl")}

--- a/dynsem/syntax/Signatures.sdf3
+++ b/dynsem/syntax/Signatures.sdf3
@@ -53,14 +53,6 @@ template options
 
   tokenize: "<("
   
-context-free syntax // semantic component declarations
-
-  SignatureSection.SemanticComponents = <
-    semantic components
-      <{SemanticCompDecl "\n"}*>>
-  
-  SemanticCompDecl.SemanticComponent = [[ID] -> [MapType]]
-
 context-free syntax // native data types
 
   SignatureSection.NativeDataTypes = <

--- a/dynsem/syntax/Signatures.sdf3
+++ b/dynsem/syntax/Signatures.sdf3
@@ -26,6 +26,14 @@ context-free syntax // variable schemes
   
   VariableScheme.VariableScheme = [[ID] : [Type]]
 
+context-free syntax // variable schemes
+  
+  SignatureSection.Aliases = <
+    aliases
+      <{AliasDecl "\n"}*>>
+  
+  AliasDecl.AliasDecl = [[ID] : [Type]]
+
 context-free syntax // constructor declarations
 
   SignatureSection.Constructors = <

--- a/dynsem/trans/analysis/analysis-rules.str
+++ b/dynsem/trans/analysis/analysis-rules.str
@@ -229,7 +229,7 @@ rules
     where
       <not(lookup-def(|NativeDTFun(parent-def)))> fun-name
     where
-      <lookup-prop(|SuperType()); lookup-def(|Types())> parent-def => sup-def;
+      <lookup-prop(|NativeTypeSuperType()); lookup-def(|Types())> parent-def => sup-def;
       <lookup-prop(|SortKind())> sup-def => NativeSort()
 
 rules // type rules for match-sides
@@ -459,7 +459,7 @@ rules
     where
       ty-from-def := <lookup-def(|Types())> ty-from;
       NativeSort() := <lookup-prop(|SortKind())> ty-from-def;
-      sup-ty := <lookup-prop(|SuperType())> ty-from-def
+      sup-ty := <lookup-prop(|NativeTypeSuperType())> ty-from-def
   
   type-coerce(coerce-s):
     (ty-from, ty-to) -> <type-coerce(coerce-s)> (<get-alias-base> ty-from, ty-to)

--- a/dynsem/trans/analysis/analysis-rules.str
+++ b/dynsem/trans/analysis/analysis-rules.str
@@ -459,6 +459,30 @@ rules
       ty-from-def := <lookup-def(|Types())> ty-from;
       NativeSort() := <lookup-prop(|SortKind())> ty-from-def;
       sup-ty := <lookup-prop(|SuperType())> ty-from-def
+  
+  type-coerce(coerce-s):
+    (ty-from, ty-to) -> <type-coerce(coerce-s)> (<get-alias-base> ty-from, ty-to)
+    where
+      <is-alias> ty-from
+  
+  type-coerce(coerce-s):
+    (ty-from, ty-to) -> <type-coerce(coerce-s)> (ty-from, <get-alias-base> ty-to)
+    where
+      <is-alias> ty-to
+
+  is-alias = where(lookup-def(|Types()); lookup-prop(|SortKind()) => AliasSort())
+  
+  get-alias-base:
+    ty -> ty'
+    where
+	    if
+        ty-def := <lookup-def(|Types())>;
+	      <lookup-prop(|SortKind())> ty-def => AliasSort()
+	    then
+	      ty' := <lookup-prop(|Type()); get-alias-base> ty-def
+	    else
+	      ty' := ty
+	    end
 
   type-coerce(coerce-s):
     (ListType(ty-from), ListType(ty-to)) -> ListType(<coerce-s> (ty-from, ty-to))

--- a/dynsem/trans/analysis/analysis-rules.str
+++ b/dynsem/trans/analysis/analysis-rules.str
@@ -6,6 +6,7 @@ imports
   analysis/constructors
   analysis/rename
   analysis/query
+  analysis/analysis-signatures
 	pp
   ds
   lib-ds
@@ -469,20 +470,6 @@ rules
     (ty-from, ty-to) -> <type-coerce(coerce-s)> (ty-from, <get-alias-base> ty-to)
     where
       <is-alias> ty-to
-
-  is-alias = where(lookup-def(|Types()); lookup-prop(|SortKind()) => AliasSort())
-  
-  get-alias-base:
-    ty -> ty'
-    where
-	    if
-        ty-def := <lookup-def(|Types())>;
-	      <lookup-prop(|SortKind())> ty-def => AliasSort()
-	    then
-	      ty' := <lookup-prop(|Type()); get-alias-base> ty-def
-	    else
-	      ty' := ty
-	    end
 
   type-coerce(coerce-s):
     (ListType(ty-from), ListType(ty-to)) -> ListType(<coerce-s> (ty-from, ty-to))

--- a/dynsem/trans/analysis/analysis-rules.str
+++ b/dynsem/trans/analysis/analysis-rules.str
@@ -201,13 +201,7 @@ rules
   type-check-build-map:
     MapSelect(m-t, k-t) -> val-ty
     where
-      maybe-map-ty := <type-check-build> m-t;
-      if <?MapType(key-ty, val-ty)> maybe-map-ty
-      then
-        id
-      else
-        <lookup-def(|Types()); lookup-prop(|SuperType())> maybe-map-ty => MapType(key-ty, val-ty)
-      end;
+      MapType(key-ty, val-ty) := <type-check-build> m-t;
       k-ty := <type-check-build> k-t;
       <type-coerce-full(fail)> (k-ty, key-ty)
 
@@ -474,14 +468,11 @@ rules
     (IntType(), RealType()) -> RealType()
   
   type-coerce(coerce-s):
-    (MapType(a-k-ty, a-v-ty), to-ty) -> to-ty
+    (MapType(a-k-ty, a-v-ty), MapType(t-k-ty, t-v-ty)) -> MapType(k-ty, v-ty)
     where
-      <lookup-def(|Types())> to-ty => to-ty-def;
-      <lookup-prop(|SortKind())> to-ty-def => SemanticCompSort();
-      <lookup-prop(|SuperType())> to-ty-def => MapType(e-k-ty, e-v-ty);
-      <coerce-s> (a-k-ty, e-k-ty);
-      <coerce-s> (a-v-ty, e-v-ty)
-
+      k-ty := <coerce-s> (a-k-ty, t-k-ty);
+      v-ty := <coerce-s> (a-v-ty, t-v-ty)
+  
   type-coerce-implicit(is-matching, coerce-s):
     (ty-from, ty-to) -> ty-to'
     where

--- a/dynsem/trans/analysis/analysis-signatures.str
+++ b/dynsem/trans/analysis/analysis-signatures.str
@@ -90,7 +90,7 @@ rules /* store signatures */
       <store-def(|Types())> name => name-def;
       <store-prop(|SortKind(), name-def)> NativeSort();
       <store-prop(|NativeTypeJString(), name-def)> javastring;
-      <store-prop(|SuperType(), name-def)> sup;
+      <store-prop(|NativeTypeSuperType(), name-def)> sup;
       <map(store-native-datatype-op(|name-def))> func*
       
   store-native-datatype-op(|par-def):

--- a/dynsem/trans/analysis/analysis-signatures.str
+++ b/dynsem/trans/analysis/analysis-signatures.str
@@ -154,6 +154,12 @@ rules
       add-msg(|Error(), s, $[Duplicate sort [s]])
   
   check-signature:
+    d@AliasDecl(s, _) -> <fail>
+    where
+      <is-alias; not(get-alias-base)> s;
+      <add-msg(|Error(), s, $[Inconsistent aliasing chain for sort [s]])> d
+  
+  check-signature:
     vs@VariableScheme(prefix, _) -> <fail>
     where
 	    <get-matching-varschemes> prefix => [_, _ | _];

--- a/dynsem/trans/analysis/analysis-signatures.str
+++ b/dynsem/trans/analysis/analysis-signatures.str
@@ -138,51 +138,55 @@ rules
   
   check-signatures = alltd(check-signature)
   
-  check-signature =
-    ?SimpleSort(s);
-    <id-to-type; not(lookup-def(|Types()))> s;
-    add-msg(|Error(), s, $[Sort [s] is not declared])
-
-  check-signature =
-    (
-      ?SortDecl(s)
-      + ?NativeBaseTypeDecl(_, s, _)
-      + ?NativeSubTypeDecl(_, s, _, _)
-    );
-    <lookup-defs(|Types())> s => [_, _ | _];
-    add-msg(|Error(), s, $[Duplicate sort [s]])
+  check-signature:
+    SimpleSort(s) -> <fail>
+    where
+      <id-to-type; not(lookup-def(|Types()))> s;
+      add-msg(|Error(), s, $[Sort [s] is not declared])
   
-  check-signature =
-    ?vs@VariableScheme(prefix, _);
-    <get-matching-varschemes> prefix => [_, _ | _];
-    add-msg(|Error(), vs, $[Duplicate or overlapping variable prefix [prefix]])
+  check-signature:
+    <?SortDecl(s)
+    + ?AliasDecl(s, _)
+    + ?NativeBaseTypeDecl(_, s, _)
+    + ?NativeSubTypeDecl(_, s, _, _)> -> <fail>
+    where
+      <lookup-defs(|Types())> s => [_, _ | _];
+      add-msg(|Error(), s, $[Duplicate sort [s]])
   
-  check-signature =
-    ?Con(cname, _);
-    <not(lookup-def(|Constructors()))> cname;
-    add-msg(|Error(), cname, $[Constructor [cname] is not declared])
+  check-signature:
+    vs@VariableScheme(prefix, _) -> <fail>
+    where
+	    <get-matching-varschemes> prefix => [_, _ | _];
+	    add-msg(|Error(), vs, $[Duplicate or overlapping variable prefix [prefix]])
   
-  check-signature =
-    (
-      ?NativeOpDecl(c, _, _)
-      + ?ConsDecl(c, _, _, _)
-      + ?NativeConsDecl(c, _, _)
-    );
-    <lookup-defs(|Constructors())> c => [_, _ | _];
-    add-msg(|Error(), c, $[Duplicate constructor [c]])
+  check-signature:
+    Con(cname, _) -> <fail>
+    where
+      <not(lookup-def(|Constructors()))> cname;
+      add-msg(|Error(), cname, $[Constructor [cname] is not declared])
+  
+  check-signature:
+    <?NativeOpDecl(c, _, _)
+    + ?ConsDecl(c, _, _, _)
+    + ?NativeConsDecl(c, _, _)> -> <fail>
+    where
+      <lookup-defs(|Constructors())> c => [_, _ | _];
+      add-msg(|Error(), c, $[Duplicate constructor [c]])
 
-  check-signature =
-    ?ConsDecl(c, [_, _ | _], _, <id>);
-    fetch-elem(?ImplicitAnno());
-    add-msg(|Error(), c, $[Only unary constructors may be implicit])
+  check-signature:
+    ConsDecl(c, [_, _ | _], _, <id>) -> <fail>
+    where
+      fetch-elem(?ImplicitAnno());
+      add-msg(|Error(), c, $[Only unary constructors may be implicit])
 
-  check-signature =
-    ?decl@ArrowDecl(in-srt, name, out-srt);
-    in-ty := <rw-type> in-srt;
-    out-ty := <rw-type> out-srt;
-    arrow-def := <lookup-def(|Arrows())> name;
-    arrow-ty* := <lookup-props(|Type()); filter(not(?ArrowType(in-ty, out-ty))); make-set> arrow-def;
-    <fetch-elem(?ArrowType(<id>, _); !(<id>, in-ty); type-coerce-sym(type-coerce-full(id)))> arrow-ty*;
-    add-msg(|Error(), decl, $[Arrow LHS overlaps with another arrow with the same name])
+  check-signature:
+    decl@ArrowDecl(in-srt, name, out-srt) -> <fail>
+    where
+	    in-ty := <rw-type> in-srt;
+	    out-ty := <rw-type> out-srt;
+	    arrow-def := <lookup-def(|Arrows())> name;
+	    arrow-ty* := <lookup-props(|Type()); filter(not(?ArrowType(in-ty, out-ty))); make-set> arrow-def;
+	    <fetch-elem(?ArrowType(<id>, _); !(<id>, in-ty); type-coerce-sym(type-coerce-full(id)))> arrow-ty*;
+	    add-msg(|Error(), decl, $[Arrow LHS overlaps with another arrow with the same name])
 
     

--- a/dynsem/trans/analysis/analysis-signatures.str
+++ b/dynsem/trans/analysis/analysis-signatures.str
@@ -17,6 +17,7 @@ rules /* store signatures */
       <+ store-arrows
       <+ store-native-datatypes
       <+ store-variable-schemes
+      <+ store-aliases
     ))
   
   store-built-ins =
@@ -105,6 +106,15 @@ rules /* store signatures */
     with
       <store-def(|VarSchemes())> prefix => scheme-def;
       <store-prop(|Type(), scheme-def)> <rw-type> ty
+
+  store-aliases = Aliases(map(store-alias))
+  
+  store-alias:
+    d@AliasDecl(name, ty) -> d
+    with
+      <store-def(|Types())> name => alias-ty-def;
+      <store-prop(|SortKind(), alias-ty-def)> AliasSort();
+      <store-prop(|Type(), alias-ty-def)> <rw-type> ty
 
 rules
   

--- a/dynsem/trans/analysis/analysis-signatures.str
+++ b/dynsem/trans/analysis/analysis-signatures.str
@@ -16,7 +16,6 @@ rules /* store signatures */
       <+ store-native-operators
       <+ store-arrows
       <+ store-native-datatypes
-      <+ store-semantic-components
       <+ store-variable-schemes
     ))
   
@@ -98,15 +97,6 @@ rules /* store signatures */
     with
       <store-def(|NativeDTFun(par-def))> name => name-def;
       <store-prop(|Type(), name-def)> FunctionType(<rw-type> arg*, <rw-type> s)
-
-  store-semantic-components = SemanticComponents(map(store-semantic-component))
-  
-  store-semantic-component:
-    d@SemanticComponent(name, MapSort(key-ty, val-ty)) -> d
-    with
-      <store-def(|Types())> name => name-def;
-      <store-prop(|SortKind(), name-def)> SemanticCompSort();
-      <store-prop(|SuperType(), name-def)> MapType(<rw-type> key-ty, <rw-type> val-ty)
 
   store-variable-schemes = VariableSchemes(map(store-variable-scheme))
   

--- a/dynsem/trans/analysis/analysis-signatures.str
+++ b/dynsem/trans/analysis/analysis-signatures.str
@@ -116,6 +116,24 @@ rules /* store signatures */
       <store-prop(|SortKind(), alias-ty-def)> AliasSort();
       <store-prop(|Type(), alias-ty-def)> <rw-type> ty
 
+  is-alias = where(lookup-def(|Types()); lookup-prop(|SortKind()) => AliasSort())
+  
+  get-alias-base = get-alias-base(|[<id>])
+  
+  get-alias-base(|acc):
+    ty -> ty'
+    where
+      if
+        ty-def := <lookup-def(|Types())>;
+        <lookup-prop(|SortKind())> ty-def => AliasSort()
+      then
+        ty-alias := <lookup-prop(|Type())> ty-def;
+        <not(fetch-elem(?ty-alias))> acc;
+        ty' := <get-alias-base(|[ty-alias | acc])> ty-alias
+      else
+        ty' := ty
+      end
+  
 rules
   
   check-signatures = alltd(check-signature)
@@ -166,4 +184,5 @@ rules
     arrow-ty* := <lookup-props(|Type()); filter(not(?ArrowType(in-ty, out-ty))); make-set> arrow-def;
     <fetch-elem(?ArrowType(<id>, _); !(<id>, in-ty); type-coerce-sym(type-coerce-full(id)))> arrow-ty*;
     add-msg(|Error(), decl, $[Arrow LHS overlaps with another arrow with the same name])
+
     

--- a/dynsem/trans/analysis/constructors.str
+++ b/dynsem/trans/analysis/constructors.str
@@ -49,6 +49,7 @@ signature
     LanguageSort: SortKind
   	NativeSort: SortKind
   	SystemSort: SortKind
+  	AliasSort: SortKind
   	
   	ConsKind: Property
   	LanguageCons: ConsKind

--- a/dynsem/trans/analysis/constructors.str
+++ b/dynsem/trans/analysis/constructors.str
@@ -47,7 +47,6 @@ signature
   constructors
     SortKind: Property
     LanguageSort: SortKind
-  	SemanticCompSort: SortKind
   	NativeSort: SortKind
   	SystemSort: SortKind
   	

--- a/dynsem/trans/analysis/constructors.str
+++ b/dynsem/trans/analysis/constructors.str
@@ -17,9 +17,9 @@ signature
     Property
 
   constructors
-    SuperType: Property
     Type: Property
     NativeTypeJString: Property
+    NativeTypeSuperType : Property
     Use: Property
     
 signature

--- a/dynsem/trans/backend/java-backend/emit-arrows.str
+++ b/dynsem/trans/backend/java-backend/emit-arrows.str
@@ -18,24 +18,24 @@ rules
   
   // generate indexed method parameter declaration
   ds2java-method-paramdecl:
-    (idx, ty) -> param |[ ~x:<ds2java-sort-classname> ty ~x:$[_[idx]] ]|
+    (idx, ty) -> param |[ ~x:<ds2java-sort-to-classname> ty ~x:$[_[idx]] ]|
   
   // generate indexed field declaration
   ds2java-fielddecl:
-    (idx, ty) -> class-body-dec |[ public ~x:<ds2java-sort-classname> ty ~x:$[_[idx]]; ]|
+    (idx, ty) -> class-body-dec |[ public ~x:<ds2java-sort-to-classname> ty ~x:$[_[idx]]; ]|
     where
       <not(type-is-adoptable + type-is-adoptable-list)> ty
 
   // generate indexed field declaration
   ds2java-fielddecl:
-    (idx, ty) -> class-body-dec |[ @Child public ~x:<ds2java-sort-classname> ty ~x:$[_[idx]]; ]|
+    (idx, ty) -> class-body-dec |[ @Child public ~x:<ds2java-sort-to-classname> ty ~x:$[_[idx]]; ]|
     where
       <type-is-adoptable> ty;
       <not(type-is-adoptable-list)> ty
 
   // generate indexed field declaration
   ds2java-fielddecl:
-    (idx, ty) -> class-body-dec |[ @Children public ~x:<ds2java-sort-classname> ty ~x:$[_[idx]]; ]|
+    (idx, ty) -> class-body-dec |[ @Children public ~x:<ds2java-sort-to-classname> ty ~x:$[_[idx]]; ]|
     where
       <type-is-adoptable-list> ty
   
@@ -72,7 +72,7 @@ rules
   ds2java-getter:
     (idx, ty) ->
       class-body-dec |[
-        public ~x:<ds2java-sort-classname> ty ~x:$[get_[idx]]() {
+        public ~x:<ds2java-sort-to-classname> ty ~x:$[get_[idx]]() {
           return this.~x:$[_[idx]];
         }
       ]|
@@ -118,7 +118,7 @@ rules
 			]|
    where
      x_classname := <ds2java-returnclassname> (arrow-def, bu-ty);
-     x_valueclass := <ds2java-sort-classname> bu-ty;
+     x_valueclass := <ds2java-sort-to-classname> bu-ty;
      changeable* := <lookup-arrow-changeables> arrow-def;
      param* := <map-with-index(ds2java-method-paramdecl)> changeable*;
      fdec* := <map-with-index(ds2java-fielddecl)> changeable*;

--- a/dynsem/trans/backend/java-backend/emit-atermconversion.str
+++ b/dynsem/trans/backend/java-backend/emit-atermconversion.str
@@ -46,7 +46,6 @@ rules
   		f-ty-def := <lookup-def(|Types())> f-ty;
   		f-ty-knd := <lookup-prop(|SortKind())> f-ty-def;
   		<not(?SystemSort())> f-ty-knd;
-  		<not(?SemanticCompSort())> f-ty-knd;
   		<not(?NativeSort())> f-ty-knd
 
   ds2java-atermconversion-name(|e):
@@ -61,12 +60,10 @@ rules
       <?NativeSort()> f-ty-knd
 
   ds2java-atermconversion-name(|e):
-  	f-ty -> e |[ AutoMapUtils.x_map2aterm(e, factory) ]|
-  	where
-  		f-ty-def := <lookup-def(|Types())> f-ty;
-      <lookup-prop(|SortKind())> f-ty-def => SemanticCompSort();
-      x_map2aterm := <def-get-name; ds2java-map2aterm-name> f-ty-def
-  
+    m-ty@MapType(_, _) -> e |[ AutoMapUtils.x_map2aterm(e, factory) ]|
+    where
+      x_map2aterm := <ds2java-map2aterm-name> m-ty
+
   ds2java-atermconversion-name(|e):
     ListType(_) -> e |[ e.toStrategoTerm(factory) ]|
   

--- a/dynsem/trans/backend/java-backend/emit-constructorclasses.str
+++ b/dynsem/trans/backend/java-backend/emit-constructorclasses.str
@@ -35,7 +35,7 @@ rules
 	      import com.github.krukow.clj_lang.PersistentTreeMap;
 
         @SuppressWarnings("unused")
-	      public class x_consname extends ~x:<ds2java-sort-classname> c-ty {
+	      public class x_consname extends ~x:<ds2java-sort-to-classname> c-ty {
 	        
 
 	        ~fdec*

--- a/dynsem/trans/backend/java-backend/emit-execmethods.str
+++ b/dynsem/trans/backend/java-backend/emit-execmethods.str
@@ -107,24 +107,24 @@ rules
     As(Var(v), con) -> [asbound*, con-bind*]
     where
     	con-bind* := <ds2java-patternbinds> con;
-    	typename := <lookup-def(|Vars()); lookup-prop(|Type()); ds2java-sort-classname> v;
+    	typename := <lookup-def(|Vars()); lookup-prop(|Type()); ds2java-sort-to-classname> v;
       asbound* := bstm* |[ final ~x:typename ~x:v = this; ]|
   
   ds2java-patternbinds:
   	Cast(Var(v), _) -> asbound*
   	where
-      typename := <lookup-def(|Vars()); lookup-prop(|Type()); ds2java-sort-classname> v;
+      typename := <lookup-def(|Vars()); lookup-prop(|Type()); ds2java-sort-to-classname> v;
       asbound* := bstm* |[ final ~x:typename ~x:v = this; ]|
       
   ds2java-componentbind:
   	(idx, LabelComp(_, Var(v))) -> bstm |[ final ~x:typename ~x:v = ~x:$[_[idx]]; ]|
   	where
-  		typename := <lookup-def(|Vars()); lookup-prop(|Type()); ds2java-sort-classname> v
+  		typename := <lookup-def(|Vars()); lookup-prop(|Type()); ds2java-sort-to-classname> v
 
   ds2java-patternboundbind:
   	(idx, Var(v)) -> bstm |[ final ~x:typename ~x:v = this.~x:$[_[idx]]; ]|
   	where
-  		typename := <lookup-def(|Vars()); lookup-prop(|Type()); ds2java-sort-classname> v
+  		typename := <lookup-def(|Vars()); lookup-prop(|Type()); ds2java-sort-to-classname> v
 
   inject-try-or(on-norule-generator|arrow):
     p*@[_|_] -> p*
@@ -207,14 +207,14 @@ rules
       e_lhs := <ds2java-term-build(|ma-ty)> lhs;
       exec := <ds2java-methodname> (arrow-def, bu-ty);
       e* := <map(\ LabelComp(ty, c) -> <ds2java-term-build-optcast(|ty)> c \)> [r*, sc*];
-      vout-ty := <type-of; ds2java-sort-classname> vdec;
+      vout-ty := <type-of; ds2java-sort-to-classname> vdec;
       bstm1* := <map(?LabelComp(_, <id>)); map-with-index(ds2java-bind-out-var(|x_tmp))> tc*;
       bstm* := <ds2java-premise> on-succ*
 
   ds2java-bind-out-var(|x_result):
     (idx, Var(v)) -> bstm |[ final ~x:v-ty ~x:v = x_result.~x:$[get_[idx]](); ]|
     where
-      v-ty := <lookup-def(|Vars()); lookup-prop(|Type()); ds2java-sort-classname> v
+      v-ty := <lookup-def(|Vars()); lookup-prop(|Type()); ds2java-sort-to-classname> v
       
   ds2java-premise:
     (MergePoint(p, PremiseBlock(p1*), PremiseBlock(p2*)), _, _) -> <ds2java-premise> (p, p1*, p2*)
@@ -250,7 +250,7 @@ rules
       rules(
         LiftedMethods:+ _ ->
           class-body-dec |[
-            private boolean x_antimatch(~x:<ds2java-sort-classname> vin-ty x_inputtmp) {
+            private boolean x_antimatch(~x:<ds2java-sort-to-classname> vin-ty x_inputtmp) {
               bstm0*
               return true;
             }
@@ -276,7 +276,7 @@ rules
   ds2java-premise:
     (Formula(Match(lhs, dec@MatchedVar(v))), on-succ*, _) ->
       bstm* |[
-        final ~x:<ds2java-sort-classname> v-ty ~x:v = e_lhs;
+        final ~x:<ds2java-sort-to-classname> v-ty ~x:v = e_lhs;
         bstm*
       ]|
     where
@@ -314,8 +314,8 @@ rules
         }
       ]|
     where
-      hd-ty := <type-of; ds2java-sort-classname> hd;
-      tl-ty := <type-of; ds2java-sort-classname> tl;
+      hd-ty := <type-of; ds2java-sort-to-classname> hd;
+      tl-ty := <type-of; ds2java-sort-to-classname> tl;
       bstm1* := <ds2java-premise> on-succ*;
       bstm2* := <ds2java-premise> on-fail*
 
@@ -367,7 +367,7 @@ rules
         }
       ]|
     where
-      ty := <rw-type; ds2java-sort-classname> ty-trm;
+      ty := <rw-type; ds2java-sort-to-classname> ty-trm;
       bstm1* := <ds2java-premise> on-succ*;
       bstm2* := <ds2java-premise> on-fail*
 
@@ -435,9 +435,9 @@ rules
   	where
   		if <?ListType(_)> ex_ty
   		then
-  			x_type := <ds2java-sort-classname> ex_ty
+  			x_type := <ds2java-sort-to-classname> ex_ty
   		else
-  			x_type := <ds2java-sort-classname> ListType(ex_ty)
+  			x_type := <ds2java-sort-to-classname> ListType(ex_ty)
   		end 
   
   ds2java-term-build(|ex-ty):
@@ -452,14 +452,14 @@ rules
       else
         actual_ex_elem_ty := h-ex-elem-ty
       end;
-      x_type := <ds2java-sort-classname> ListType(actual_ex_elem_ty);
+      x_type := <ds2java-sort-to-classname> ListType(actual_ex_elem_ty);
       e_t := <ds2java-term-build(|ListType(actual_ex_elem_ty))> t-trm
   
   ds2java-term-build(|ex_ty):
     Cast(t, ty-trm) -> e |[ (x_ty) e_t ]|
     where
       e_t := <ds2java-term-build(|<try(rw-type)> ty-trm)> t;
-      x_ty := <try(rw-type); ds2java-sort-classname> ty-trm
+      x_ty := <try(rw-type); ds2java-sort-to-classname> ty-trm
   
   ds2java-term-build(|ex_ty):
     String(s) -> Lit(String([Chars(<unquote(?'"')> s)]))
@@ -484,8 +484,8 @@ rules
   ds2java-term-build(|ex_ty):
     Map([Bind(key, val)]) -> e |[ new com.github.krukow.clj_lang.PersistentTreeMap<x_keyty, x_valty>().plus(e_key, e_val) ]|
     where
-      x_keyty := <type-of; ds2java-sort-classname; ds2java-box-java-type> key;
-      x_valty := <type-of; ds2java-sort-classname; ds2java-box-java-type> val;
+      x_keyty := <type-of; ds2java-sort-to-classname; box-primitive-type> key;
+      x_valty := <type-of; ds2java-sort-to-classname; box-primitive-type> val;
       e_key := <ds2java-term-build(|ALPHATYPE())> key;
       e_val := <ds2java-term-build(|ALPHATYPE())> val
 

--- a/dynsem/trans/backend/java-backend/emit-execmethods.str
+++ b/dynsem/trans/backend/java-backend/emit-execmethods.str
@@ -378,18 +378,9 @@ rules
     )
   
   ds2java-term-build-optcast(|ex_ty):
-    trm -> <ds2java-term-build(|ex_ty)> Cast(trm, ex_ty')
+    trm -> <ds2java-term-build(|ex_ty)> Cast(trm, ex_ty)
     where
       <type-of> trm => MapType(ALPHATYPE(), ALPHATYPE())
-    where
-    	if !ex_ty => MapType(_, _)
-    	then
-    		ex_ty' := ex_ty
-    	else
-    		ex_ty_def := <lookup-def(|Types())> ex_ty;
-    		<lookup-prop(|SortKind())> ex_ty_def => SemanticCompSort();
-    		ex_ty' := <lookup-prop(|SuperType())> ex_ty_def
-      end
 
   ds2java-term-build:
     (ty, t) -> <ds2java-term-build(|ty)> t

--- a/dynsem/trans/backend/java-backend/emit-genericnodes.str
+++ b/dynsem/trans/backend/java-backend/emit-genericnodes.str
@@ -82,7 +82,7 @@ rules
         }
       ]|
     where
-      sortname := <ds2java-sort-classname> ty;
+      sortname := <ds2java-sort-to-classname> ty;
       gennodename := $[Generic_[sortname]];
       c-def* := <lookup-def-all(|Constructors()); filter(where(lookup-prop(|Type()) => ConstructorType(_, ty)); where(lookup-prop(|ConsKind()) => LanguageCons()))>;
       impl-c-def* := <lookup-def-all(|Constructors()); filter(where(lookup-prop(|Type()) => ConstructorType(_, ty)); where(lookup-prop(|ConsKind()) => ImplicitCons()))>;
@@ -102,7 +102,7 @@ rules
     where
       c-name := <def-get-name> c-def;
       ConstructorType(c-c-ty*, c-ty) := <lookup-prop(|Type())> c-def;
-      sortname := <ds2java-sort-classname> c-ty;
+      sortname := <ds2java-sort-to-classname> c-ty;
       consname := <ds2java-constr-classname> c-name;
       e* := <map-with-index((\ idx -> e |[ term.getSubterm(~i:<dec; int-to-string> idx)]| \, id); ds2java-gennode-instantiation)> c-c-ty*
   
@@ -116,12 +116,12 @@ rules
       ty-def := <lookup-def(|Types())> ty;
       <not(lookup-prop(|SortKind()) => SystemSort())> ty-def;
       <not(lookup-prop(|SortKind()) => NativeSort())> ty-def;
-      gennodename := $[Generic_[<ds2java-sort-classname> ty]]
+      gennodename := $[Generic_[<ds2java-sort-to-classname> ty]]
 
   ds2java-gennode-instantiation:
     (e_trm, lty@ListType(e-ty)) -> e |[ new x_listname(NodeSource.fromStrategoTerm(e_trm)).fromStrategoTerm(e_trm) ]|
     where
-      x_listname := <ds2java-sort-classname> lty
+      x_listname := <ds2java-sort-to-classname> lty
   
   ds2java-gennode-instantiation:
     (e_trm, m-ty@MapType(_, _)) -> e |[ AutoMapUtils.x_tosemcomp(e_trm) ]|
@@ -161,7 +161,7 @@ rules
 			]|
 		where
 			ConstructorType([c-ty], ty) := <lookup-prop(|Type())> impl-c-def;
-			x_sortname := <ds2java-sort-classname> c-ty;
+			x_sortname := <ds2java-sort-to-classname> c-ty;
 			x_implnodename := <def-get-name; ds2java-constr-classname> impl-c-def;
 			gennodename := $[Generic_[x_sortname]]
 

--- a/dynsem/trans/backend/java-backend/emit-genericnodes.str
+++ b/dynsem/trans/backend/java-backend/emit-genericnodes.str
@@ -115,7 +115,6 @@ rules
       not(!ty => ListType(_));
       ty-def := <lookup-def(|Types())> ty;
       <not(lookup-prop(|SortKind()) => SystemSort())> ty-def;
-      <not(lookup-prop(|SortKind()) => SemanticCompSort())> ty-def;
       <not(lookup-prop(|SortKind()) => NativeSort())> ty-def;
       gennodename := $[Generic_[<ds2java-sort-classname> ty]]
 
@@ -125,12 +124,9 @@ rules
       x_listname := <ds2java-sort-classname> lty
   
   ds2java-gennode-instantiation:
-    (e_trm, ty) -> e |[ AutoMapUtils.x_tosemcomp(e_trm) ]|
+    (e_trm, m-ty@MapType(_, _)) -> e |[ AutoMapUtils.x_tosemcomp(e_trm) ]|
     where
-      ty-def := <lookup-def(|Types())> ty;
-      <lookup-prop(|SortKind())> ty-def => SemanticCompSort();
-      ty-name := <def-get-name> ty-def;
-      x_tosemcomp := <ds2java-aterm2map-name> ty-name
+      x_tosemcomp := <ds2java-aterm2map-name> m-ty
  
   ds2java-gennode-instantiation:
   	(e_trm, ty) -> e |[ null ]|

--- a/dynsem/trans/backend/java-backend/emit-listclasses.str
+++ b/dynsem/trans/backend/java-backend/emit-listclasses.str
@@ -32,47 +32,10 @@ rules
       x_classname := <ds2java-sort-to-classname> lty;
       specializer* := <mklist-specializer(|x_classname, ety) <+ ![]>;
       exec* := <ds2java-execmethods(ds2java-throw-statement|rule*)> lty;
-  		if
-  		  sup-ty := <lookup-def(|Types()); lookup-prop(|SuperType())> ety
-  		then
-  			x_supername := <lookup-def(|Types()); def-get-name; !ListSort(SimpleSort(<id>)); rw-type; ds2java-sort-to-classname> sup-ty;
-  			class := <mklist-class(|x_classname, x_supername, ety, [specializer*, exec*])>
-			else
-				class := <mklist-class(|x_classname, ety, [specializer*, exec*])>
-			end
+		  class := <mklist-class(|x_classname, ety, [specializer*, exec*])>
   
 rules
 	
-  mklist-class(|x_classname, x_supername, elemtype, exec*) =
-  	body* := <mklist-class-body(|x_classname, elemtype, exec*)>;
-  	x_elemname := <ds2java-sort-to-classname; box-primitive-type> elemtype;
-  	!compilation-unit |[
-  		package ~x:<AutoPackageName>;
-        
-        import org.metaborg.meta.interpreter.framework.*;
-        import org.spoofax.interpreter.terms.*;
-        import org.spoofax.jsglr.client.imploder.ImploderAttachment;
-        import com.github.krukow.clj_lang.PersistentTreeMap;
-        
-        public class x_classname extends x_supername implements INodeList {
-          public INodeSource source;
-          
-          public x_classname(INodeSource source) {
-            this(source, null, null);
-          }
-          
-          public x_classname(INodeSource source, x_elemname head, x_classname tail) {
-            super(source, head, tail);
-            this.source = source;
-            this.head = head;
-            this.tail = tail;
-            this.size = (head == null ? 0 : 1) + (tail == null ? 0 : tail.size());
-          }
-          
-        	~body*
-        }
-  	]|
- 
   mklist-class(|x_classname, elemty, exec*) =
     body* := <mklist-class-body(|x_classname, elemty, exec*)>;
     x_elemname := <ds2java-sort-to-classname; box-primitive-type> elemty;

--- a/dynsem/trans/backend/java-backend/emit-listclasses.str
+++ b/dynsem/trans/backend/java-backend/emit-listclasses.str
@@ -29,13 +29,13 @@ rules
   ds2java-listclass(|rule*):
   	lty@ListType(ety) -> class
     where
-      x_classname := <ds2java-sort-classname> lty;
+      x_classname := <ds2java-sort-to-classname> lty;
       specializer* := <mklist-specializer(|x_classname, ety) <+ ![]>;
       exec* := <ds2java-execmethods(ds2java-throw-statement|rule*)> lty;
   		if
   		  sup-ty := <lookup-def(|Types()); lookup-prop(|SuperType())> ety
   		then
-  			x_supername := <lookup-def(|Types()); def-get-name; !ListSort(SimpleSort(<id>)); rw-type; ds2java-sort-classname> sup-ty;
+  			x_supername := <lookup-def(|Types()); def-get-name; !ListSort(SimpleSort(<id>)); rw-type; ds2java-sort-to-classname> sup-ty;
   			class := <mklist-class(|x_classname, x_supername, ety, [specializer*, exec*])>
 			else
 				class := <mklist-class(|x_classname, ety, [specializer*, exec*])>
@@ -45,7 +45,7 @@ rules
 	
   mklist-class(|x_classname, x_supername, elemtype, exec*) =
   	body* := <mklist-class-body(|x_classname, elemtype, exec*)>;
-  	x_elemname := <ds2java-sort-classname; ds2java-box-java-type> elemtype;
+  	x_elemname := <ds2java-sort-to-classname; box-primitive-type> elemtype;
   	!compilation-unit |[
   		package ~x:<AutoPackageName>;
         
@@ -75,7 +75,7 @@ rules
  
   mklist-class(|x_classname, elemty, exec*) =
     body* := <mklist-class-body(|x_classname, elemty, exec*)>;
-    x_elemname := <ds2java-sort-classname; ds2java-box-java-type> elemty;
+    x_elemname := <ds2java-sort-to-classname; box-primitive-type> elemty;
     !compilation-unit |[
       package ~x:<AutoPackageName>;
         
@@ -103,7 +103,7 @@ rules
     ]|
 
   mklist-class-body(|x_classname, elemty, exec*) =
-  	x_elemname := <ds2java-sort-classname; ds2java-box-java-type> elemty;
+  	x_elemname := <ds2java-sort-to-classname; box-primitive-type> elemty;
   	!class-body-dec* |[
   		    @Child
           public x_elemname head;
@@ -191,7 +191,7 @@ rules
   mklist-specializer(|x_classname, e-ty) =
     e-ty-def := <lookup-def(|Types())> e-ty;
     where(<lookup-prop(|SortKind())> e-ty-def => LanguageSort());
-    x_genelem := $[Generic_[<ds2java-sort-classname> e-ty]];
+    x_genelem := $[Generic_[<ds2java-sort-to-classname> e-ty]];
     !class-body-dec* |[
     	@Override
       public x_classname fromStrategoTerm(IStrategoTerm alist) {

--- a/dynsem/trans/backend/java-backend/emit-listclasses.str
+++ b/dynsem/trans/backend/java-backend/emit-listclasses.str
@@ -32,15 +32,14 @@ rules
       x_classname := <ds2java-sort-classname> lty;
       specializer* := <mklist-specializer(|x_classname, ety) <+ ![]>;
       exec* := <ds2java-execmethods(ds2java-throw-statement|rule*)> lty;
-  		ety-def := <lookup-def(|Types())> ety;
-  		if sup-ty := <lookup-prop(|SuperType())> ety-def
+  		if
+  		  sup-ty := <lookup-def(|Types()); lookup-prop(|SuperType())> ety
   		then
   			x_supername := <lookup-def(|Types()); def-get-name; !ListSort(SimpleSort(<id>)); rw-type; ds2java-sort-classname> sup-ty;
   			class := <mklist-class(|x_classname, x_supername, ety, [specializer*, exec*])>
 			else
 				class := <mklist-class(|x_classname, ety, [specializer*, exec*])>
 			end
-  
   
 rules
 	

--- a/dynsem/trans/backend/java-backend/emit-listclasses.str
+++ b/dynsem/trans/backend/java-backend/emit-listclasses.str
@@ -33,7 +33,7 @@ rules
       specializer* := <mklist-specializer(|x_classname, ety) <+ ![]>;
       exec* := <ds2java-execmethods(ds2java-throw-statement|rule*)> lty;
   		ety-def := <lookup-def(|Types())> ety;
-  		if sup-ty := <lookup-prop(|SuperType())> ety-def; <not(lookup-prop(|SortKind()); ?SemanticCompSort())> ety-def
+  		if sup-ty := <lookup-prop(|SuperType())> ety-def
   		then
   			x_supername := <lookup-def(|Types()); def-get-name; !ListSort(SimpleSort(<id>)); rw-type; ds2java-sort-classname> sup-ty;
   			class := <mklist-class(|x_classname, x_supername, ety, [specializer*, exec*])>

--- a/dynsem/trans/backend/java-backend/emit-maputils.str
+++ b/dynsem/trans/backend/java-backend/emit-maputils.str
@@ -17,13 +17,13 @@ imports
 rules
   
   ds2java-maputils =
-    lookup-def-all(|Types());
-    filter(where(lookup-prop(|SortKind()) => SemanticCompSort()));
-    ds2java-maputils-semcomps;
+    collect-all(?MapSort(_, _); rw-type);
+    make-set;
+    ds2java-maputils-maps;
     MkSingleton
-    
-  ds2java-maputils-semcomps:
-    semcomp-def* ->
+  
+  ds2java-maputils-maps:
+    map-ty* ->
       compilation-unit |[
         package ~x:<AutoPackageName>;
         
@@ -41,18 +41,18 @@ rules
         }
       ]|
     where
-      conv* := <mapconcat(ds2java-maputils-semcomp)> semcomp-def*
+      conv* := <mapconcat(ds2java-maputils-map)> map-ty*
   
-  ds2java-maputils-semcomp:
-    semcomp-def ->
+  ds2java-maputils-map:
+    m-ty@MapType(k-ty, v-ty) ->
       class-body-dec* |[
         public static IStrategoTerm x_toterm(PersistentMap<x_kty, x_vty> map, ITermFactory factory) {
           IStrategoConstructor bindCons = factory.makeConstructor("Bind", 2);
 
           IStrategoTerm[] kids = new IStrategoTerm[map.size() + 1];
-          kids[0] = factory.makeString(~e:Lit(String([Chars(semcomp-name)])));
+          // kids[0] = factory.makeString(~e:Lit(String([Chars(semcomp-name)])));
 
-          int idx = 1;
+          int idx = 0;
           for (Entry<x_kty, x_vty> entry : map.entrySet()) {
             kids[idx] = factory.makeAppl(bindCons,
                         e_keytrm, e_valtrm);
@@ -63,25 +63,20 @@ rules
         }
         
         public static PersistentMap<x_kty, x_vty> x_fromterm(IStrategoTerm term) {
-          final String mapName = ~e:Lit(String([Chars(semcomp-name)]));
 			    final Map<x_kty, x_vty> result = new TreeMap<x_kty, x_vty>();
 			    if (Tools.isTermAppl(term)) {
 			      IStrategoAppl appl = (IStrategoAppl) term;
 			      if (Tools.hasConstructor(appl, "Map", 2)) {
-			        IStrategoTerm kid0 = term.getSubterm(0);
-			        if (Tools.isTermString(kid0)
-			            && Tools.asJavaString(kid0).equals(mapName)) {
-			          for (int idx = 1; idx < term.getSubtermCount(); idx++) {
-			            IStrategoTerm kid = term.getSubterm(idx);
-			            if (Tools.isTermAppl(kid)) {
-			              IStrategoAppl bindAppl = (IStrategoAppl) kid;
-			              if (Tools.hasConstructor(bindAppl, "Bind", 2)) {
-			                result.put(e_key, e_value);
-			              }
-			            }
-			          }
-			          return PersistentTreeMap.create(result);
-			        }
+		          for (int idx = 1; idx < term.getSubtermCount(); idx++) {
+		            IStrategoTerm kid = term.getSubterm(idx);
+		            if (Tools.isTermAppl(kid)) {
+		              IStrategoAppl bindAppl = (IStrategoAppl) kid;
+		              if (Tools.hasConstructor(bindAppl, "Bind", 2)) {
+		                result.put(e_key, e_value);
+		              }
+		            }
+		          }
+		          return PersistentTreeMap.create(result);
 			
 			      }
 			    }
@@ -90,10 +85,8 @@ rules
 			  }
       ]|
     where
-      semcomp-name := <def-get-name> semcomp-def;
-      x_toterm := <ds2java-map2aterm-name> semcomp-name;
-      x_fromterm := <ds2java-aterm2map-name> semcomp-name;
-      MapType(k-ty, v-ty) := <lookup-prop(|SuperType())> semcomp-def;
+      x_toterm := <ds2java-map2aterm-name> m-ty;
+      x_fromterm := <ds2java-aterm2map-name> m-ty;
       x_kty := <ds2java-sort-classname; ds2java-box-java-type> k-ty;
       x_vty := <ds2java-sort-classname; ds2java-box-java-type> v-ty;
       e_keytrm := <ds2java-atermconversion-name(| e |[ entry.getKey() ]|)> k-ty;
@@ -102,7 +95,7 @@ rules
       e_value := <ds2java-gennode-instantiation> (e |[ bindAppl.getSubterm(1) ]|, v-ty)
 
   ds2java-map2aterm-name:
-  	semcomp-name -> $[toStrategoTerm_[semcomp-name]]
+    MapType(k-ty, v-ty) -> $[map_[<ds2java-sort-classname> k-ty]_[<ds2java-sort-classname> v-ty]2aterm]
 
   ds2java-aterm2map-name:
-  	semcomp-name -> $[to_[semcomp-name]]
+    MapType(k-ty, v-ty) -> $[aterm2map_[<ds2java-sort-classname> k-ty]_[<ds2java-sort-classname> v-ty]]

--- a/dynsem/trans/backend/java-backend/emit-maputils.str
+++ b/dynsem/trans/backend/java-backend/emit-maputils.str
@@ -50,7 +50,6 @@ rules
           IStrategoConstructor bindCons = factory.makeConstructor("Bind", 2);
 
           IStrategoTerm[] kids = new IStrategoTerm[map.size() + 1];
-          // kids[0] = factory.makeString(~e:Lit(String([Chars(semcomp-name)])));
 
           int idx = 0;
           for (Entry<x_kty, x_vty> entry : map.entrySet()) {
@@ -81,7 +80,7 @@ rules
 			      }
 			    }
 			
-			    throw new RuntimeException("Malformed map for " + mapName);
+			    throw new RuntimeException("Malformed map");
 			  }
       ]|
     where

--- a/dynsem/trans/backend/java-backend/emit-maputils.str
+++ b/dynsem/trans/backend/java-backend/emit-maputils.str
@@ -61,7 +61,7 @@ rules
           return factory.makeAppl(factory.makeConstructor("Map", 2), kids);
         }
         
-        public static PersistentMap<x_kty, x_vty> x_fromterm(IStrategoTerm term) {
+        public static x_maptype x_fromterm(IStrategoTerm term) {        
 			    final Map<x_kty, x_vty> result = new TreeMap<x_kty, x_vty>();
 			    if (Tools.isTermAppl(term)) {
 			      IStrategoAppl appl = (IStrategoAppl) term;
@@ -86,15 +86,16 @@ rules
     where
       x_toterm := <ds2java-map2aterm-name> m-ty;
       x_fromterm := <ds2java-aterm2map-name> m-ty;
-      x_kty := <ds2java-sort-classname; ds2java-box-java-type> k-ty;
-      x_vty := <ds2java-sort-classname; ds2java-box-java-type> v-ty;
+      x_maptype := <ds2java-sort-to-classname> m-ty;
+      x_kty := <ds2java-sort-to-classname; box-primitive-type> k-ty;
+      x_vty := <ds2java-sort-to-classname; box-primitive-type> v-ty;
       e_keytrm := <ds2java-atermconversion-name(| e |[ entry.getKey() ]|)> k-ty;
       e_valtrm := <ds2java-atermconversion-name(| e |[ entry.getValue() ]|)> v-ty;
       e_key := <ds2java-gennode-instantiation> (e |[ bindAppl.getSubterm(0) ]|, k-ty);
       e_value := <ds2java-gennode-instantiation> (e |[ bindAppl.getSubterm(1) ]|, v-ty)
 
   ds2java-map2aterm-name:
-    MapType(k-ty, v-ty) -> $[map_[<ds2java-sort-classname> k-ty]_[<ds2java-sort-classname> v-ty]2aterm]
+    MapType(k-ty, v-ty) -> $[map_[<ds2java-sort-to-id> k-ty]_[<ds2java-sort-to-id> v-ty]2aterm]
 
   ds2java-aterm2map-name:
-    MapType(k-ty, v-ty) -> $[aterm2map_[<ds2java-sort-classname> k-ty]_[<ds2java-sort-classname> v-ty]]
+    MapType(k-ty, v-ty) -> $[aterm2map_[<ds2java-sort-to-id> k-ty]_[<ds2java-sort-to-id> v-ty]]

--- a/dynsem/trans/backend/java-backend/emit-specializercode.str
+++ b/dynsem/trans/backend/java-backend/emit-specializercode.str
@@ -64,10 +64,10 @@ rules
       ]|
     where
       <type-is-adoptable-list> ty;
-      x_ty := <?ListType(<id>); ds2java-sort-classname> ty;
+      x_ty := <?ListType(<id>); ds2java-sort-to-classname> ty;
       x_idx := <mkidx> idx;
       x_idxelem := $[[x_idx]_elem];
       x_idxlist := $[[x_idx]_list];
-      x_listty := <ds2java-sort-classname> ty
+      x_listty := <ds2java-sort-to-classname> ty
 
 

--- a/dynsem/trans/backend/java-backend/emit-types.str
+++ b/dynsem/trans/backend/java-backend/emit-types.str
@@ -31,7 +31,7 @@ rules /* generate interfaces for sort declarations */
         
         import org.metaborg.meta.interpreter.framework.*;
         
-        public abstract class ~x:<def-get-name; ds2java-sort-classname> ty-def extends AbstractNode implements IMatchableNode {
+        public abstract class ~x:<def-get-name; ds2java-sort-to-classname> ty-def extends AbstractNode implements IMatchableNode {
           ~exec*
         }
       ]|

--- a/dynsem/trans/backend/java-backend/lib-ds2java.str
+++ b/dynsem/trans/backend/java-backend/lib-ds2java.str
@@ -15,7 +15,13 @@ rules /* name generation */
     where
       <not(?ALPHATYPE())> ety
     where
-      ety-str := <ds2java-listsort-elemname; ds2java-box-java-type> ety
+      switch !ety
+        case ?MapType(k-ty, v-ty):
+          ety-str := $[Map_[<ds2java-sort-classname; ds2java-box-java-type> k-ty]_[<ds2java-sort-classname; ds2java-box-java-type> v-ty]]
+        otherwise:
+          ety-str := <ds2java-listsort-elemname; ds2java-box-java-type> ety 
+      end
+      
       
   ds2java-listsort-elemname:
     ty -> <def-get-name> ty-def

--- a/dynsem/trans/backend/java-backend/lib-ds2java.str
+++ b/dynsem/trans/backend/java-backend/lib-ds2java.str
@@ -21,17 +21,6 @@ rules /* name generation */
     ty -> <def-get-name> ty-def
     where
       ty-def := <lookup-def(|Types())> ty;
-      ty-kind := <lookup-prop(|SortKind())> ty-def;
-      (
-        !ty-kind => SemanticCompSort()
-        <+
-        !ty-kind => NativeSort()
-      )  
-  
-  ds2java-listsort-elemname:
-    ty -> <def-get-name> ty-def
-    where
-      ty-def := <lookup-def(|Types())> ty;
       NativeSort() := <lookup-prop(|SortKind())> ty-def
   
   ds2java-listsort-elemname = ds2java-sort-classname
@@ -47,13 +36,6 @@ rules /* name generation */
   	where
   		kty-str := <ds2java-sort-classname; try(ds2java-box-primitive-java-type)> kty;
   		vty-str := <ds2java-sort-classname; try(ds2java-box-primitive-java-type)> vty
-  
-  ds2java-sort-classname:
-    ty -> <ds2java-sort-classname> ty'
-    where
-      ty-def := <lookup-def(|Types())> ty;
-      SemanticCompSort() := <lookup-prop(|SortKind())> ty-def;
-      ty' := <lookup-prop(|SuperType())> ty-def
   
   ds2java-sort-classname:
   	ty -> <ds2java-systemsort-classname> ty-def

--- a/dynsem/trans/backend/java-backend/lib-ds2java.str
+++ b/dynsem/trans/backend/java-backend/lib-ds2java.str
@@ -5,83 +5,95 @@ imports
   analysis/constructors
   analysis/lib-analysis
 
-rules /* name generation */
+rules /* projections of types to names */
 
-  ds2java-sort-classname:
-    ListType(ALPHATYPE()) -> "NIL"
+  ds2java-sort-to-classname = ds2java-sort-to-name(id)
   
-  ds2java-sort-classname:
-    ListType(ety) -> $[L_[ety-str]]
-    where
-      <not(?ALPHATYPE())> ety
-    where
-      switch !ety
-        case ?MapType(k-ty, v-ty):
-          ety-str := $[Map_[<ds2java-sort-classname; ds2java-box-java-type> k-ty]_[<ds2java-sort-classname; ds2java-box-java-type> v-ty]]
-        otherwise:
-          ety-str := <ds2java-listsort-elemname; ds2java-box-java-type> ety 
-      end
-      
-      
-  ds2java-listsort-elemname:
-    ty -> <def-get-name> ty-def
+  ds2java-sort-to-id = ds2java-sort-to-name(fail)
+
+  ds2java-sort-to-name(is-classname):
+    ty -> ty-str
     where
       ty-def := <lookup-def(|Types())> ty;
-      NativeSort() := <lookup-prop(|SortKind())> ty-def
+      NativeSort() := <lookup-prop(|SortKind())> ty-def;
+      if is-classname
+      then
+        ty-str := <lookup-prop(|NativeTypeJString()); unquote(?'"')> ty-def
+      else
+        ty-str := <def-get-name> ty-def
+      end
   
-  ds2java-listsort-elemname = ds2java-sort-classname
+  ds2java-sort-to-name(is-classname):
+    ty -> $[A_[<def-get-name> ty-def]]
+    where
+      ty-def := <lookup-def(|Types())> ty;
+      ty-kind := <lookup-prop(|SortKind())> ty-def;
+      <not(?SystemSort() <+ ?NativeSort())> ty-kind
   
-  ds2java-sort-classname:
+  ds2java-sort-to-name(is-classname):
+    ListType(ALPHATYPE()) -> "NIL"
+
+  ds2java-sort-to-name(is-classname):
+    ListType(ety) -> $[L_[<ds2java-sort-to-name(fail)> ety]]
+    where
+      <not(?ALPHATYPE())> ety
+      
+  ds2java-sort-to-name(is-classname):
     MapType(ALPHATYPE(), ALPHATYPE()) -> $[com.github.krukow.clj_ds.PersistentMap<?, ?>]
+    where is-classname
   
-  ds2java-sort-classname:
-  	MapType(kty, vty) -> $[com.github.krukow.clj_ds.PersistentMap<[kty-str], [vty-str]>]
-  	where not(
-  	  !(kty, vty) => (ALPHATYPE(), ALPHATYPE())
-  	)
-  	where
-  		kty-str := <ds2java-sort-classname; try(ds2java-box-primitive-java-type)> kty;
-  		vty-str := <ds2java-sort-classname; try(ds2java-box-primitive-java-type)> vty
+  ds2java-sort-to-name(is-classname):
+    MapType(kty, vty) -> $[com.github.krukow.clj_ds.PersistentMap<[kty-str], [vty-str]>]
+    where
+      is-classname;
+      <not(?ALPHATYPE())> kty;
+      <not(?ALPHATYPE())> vty
+    where
+     kty-str := <ds2java-sort-to-name(box-primitive-type)> kty;
+     vty-str := <ds2java-sort-to-name(box-primitive-type)> vty
   
-  ds2java-sort-classname:
-  	ty -> <ds2java-systemsort-classname> ty-def
-  	where
-  		ty-def := <lookup-def(|Types())> ty;
-  		SystemSort() := <lookup-prop(|SortKind())> ty-def
-
-  ds2java-sort-classname:
-  	ty -> <lookup-prop(|NativeTypeJString()); unquote(?'"')> ty-def
-  	where
-  		ty-def := <lookup-def(|Types())> ty;
-  		NativeSort() := <lookup-prop(|SortKind())> ty-def
+  ds2java-sort-to-name(is-classname):
+    MapType(ALPHATYPE(), ALPHATYPE()) -> $[Map]
+    where not(is-classname)
   
-  ds2java-sort-classname:
-  	ty -> $[A_[<def-get-name> ty-def]]
-  	where
-  		ty-def := <lookup-def(|Types())> ty
+  ds2java-sort-to-name(is-classname):
+    MapType(kty, vty) -> $[Map_[kty-str]_[vty-str]>]
+    where
+      not(is-classname);
+      <not(?ALPHATYPE())> kty;
+      <not(?ALPHATYPE())> vty
+    where
+     kty-str := <ds2java-sort-to-name(fail)> kty;
+     vty-str := <ds2java-sort-to-name(fail)> vty
 
-  ds2java-systemsort-classname:
-  	(Types(), IntType()) -> "int"
+  ds2java-sort-to-name(is-classnamee):
+    IntType() -> "int" 
   
-  ds2java-systemsort-classname:
-  	(Types(), RealType()) -> "double"
+  ds2java-sort-to-name(is-classname):
+    RealType() -> "double"
 
-  ds2java-systemsort-classname:
-  	(Types(), BoolType()) -> "boolean"
+  ds2java-sort-to-name(is-classname):
+    BoolType() -> "boolean"
 
-  ds2java-systemsort-classname:
-  	(Types(), StringType()) -> "String"
+  ds2java-sort-to-name(is-classname):
+    StringType() -> "String"
 
-  ds2java-box-java-type = try(ds2java-box-primitive-java-type)
-  
-  ds2java-box-primitive-java-type:
+  ds2java-sort-to-name(is-classname) = is-string
+
+  box-primitive-type = try(do-box-primitive-type)
+
+  do-box-primitive-type:
     "int" -> "Integer"
 
-  ds2java-box-primitive-java-type:
+  do-box-primitive-type:
     "double" -> "Double"
   
-  ds2java-box-primitive-java-type:
+  do-box-primitive-type:
     "boolean" -> "Boolean"
+
+
+rules /* name generation */
+
 
   pp-type-java =
     ?ListType(e); !$[List_[<pp-type-java> e]_]

--- a/dynsem/trans/ds.str
+++ b/dynsem/trans/ds.str
@@ -23,6 +23,7 @@ imports
 	ds2ds/expand-implicits
 	ds2ds/desugar-varschemes
 	ds2ds/extra-typeannos
+	ds2ds/desugar-aliases
 	analysis/main
 	analysis/lib-analysis
 	analysis/constructors
@@ -134,6 +135,14 @@ rules // Builders
         result := <resolve-includes(fatal-err-missing-import); desugar-top; fuse-sections; add-extra-typeannos-module; sugar-all; pp-debug> ast
       |project-path)
 
+  desugar-aliases-editor:
+    (selected, position, ast, path, project-path) -> (filename, result)
+    with
+      filename := <guarantee-extension(|"noaliases.ds")> path;
+      in-project-path(
+        result := <resolve-includes(fatal-err-missing-import); desugar-top; fuse-sections; desugar-aliases-module; sugar-all; pp-debug> ast
+      |project-path)
+
   expand-implicits-editor:
     (selected, position, ast, path, project-path) -> (filename, result)
     with
@@ -209,6 +218,9 @@ rules // Builders
 	          add-extra-typeannos-module | "Adding extra typeannos"
 	        );
 	        log-timed(
+            desugar-aliases-module | "Desugaring aliases"
+          );
+	        log-timed(
 	          factorize-module | "Factorization 1/2"
 	        );
 	        log-timed(
@@ -252,6 +264,9 @@ rules // Builders
 	        );
 	        log-timed(
 	          add-extra-typeannos-module | "Adding extra typeannos"
+	        );
+	        log-timed(
+	          desugar-aliases-module | "Desugaring aliases"
 	        );
 	        log-timed(
 	          factorize-module | "Factorization 1/2"

--- a/dynsem/trans/ds2ds/desugar-aliases.str
+++ b/dynsem/trans/ds2ds/desugar-aliases.str
@@ -1,0 +1,25 @@
+module desugar-aliases
+
+imports
+  include/ds
+  ds
+  analysis/-
+
+rules
+
+  desugar-aliases-module:
+    m@Module(_, _) -> Module($[[name]_noaliases], section*)
+    where
+      <m-in-analysis(desugar-aliases); unmark-vars> m => Module(name, section*)
+  
+  desugar-aliases = alltd(desugar-alias); Module(id, remove-alias-decls)
+  
+  desugar-alias:
+    d@SimpleSort(s) -> <derw-type> base-ty
+    where
+      ty := <rw-type> d;
+      <is-alias> ty;
+      base-ty := <get-alias-base> s
+
+  remove-alias-decls = alltd(Signatures(filter(not(?Aliases(_)))))
+

--- a/dynsem/trans/ds2ds/expand-implicits.str
+++ b/dynsem/trans/ds2ds/expand-implicits.str
@@ -67,22 +67,14 @@ rules /* lift and expand subterms on build sides */
   expand-implicits-termbuild:
     MapExtend(e, m) -> (MapExtend(e, m'), p*)
     where
-      m-ty := <type-of; not(?MapType(_, _) <+ lookup-def(|Types()); lookup-prop(|SortKind()) => SemanticCompSort())> m;
+      m-ty := <type-of; not(?MapType(_, _))> m;
       e-ty := <type-of> e;
       (m', p*) := <lift-where-indirect> (e-ty, m)
 
   expand-implicits-termbuild:
     MapExtend(Map([Bind(k, v)]), m) -> (MapExtend(Map([Bind(k', v')]), m), [p1*, p2*])
     where
-      m-ty := <type-of> m;
-      if
-        m-ty-def := <lookup-def(|Types())> m-ty;
-        <lookup-prop(|SortKind())> m-ty-def => SemanticCompSort()
-      then
-        MapType(k-ty, v-ty) := <lookup-prop(|SuperType())> m-ty-def
-      else
-        MapType(k-ty, v-ty) := m-ty
-      end;
+      MapType(k-ty, v-ty) := <type-of> m;
       (k', p1*) := <lift-where-indirect <+ !(k, [])> (k-ty, k);
       (v', p2*) := <lift-where-indirect <+ !(v, [])> (v-ty, v)
 

--- a/dynsem/trans/ds2ds/explicate.str
+++ b/dynsem/trans/ds2ds/explicate.str
@@ -20,7 +20,7 @@ rules
   
   explicate-rule :
     Rule(prem1*, infer, Relation(Reads(r1*), Source(lhs, sc1*), NamedDynamicEmitted(e1*, arrow), Target(rhs, tc1*))) ->   
-    Rule(prem3*, infer, Relation(Reads(r2*), Source(lhs, sc2*), NamedDynamicEmitted(e2*, arrow), Target(rhs, tc2*)))
+      Rule(prem3*, infer, Relation(Reads(r2*), Source(lhs, sc2*), NamedDynamicEmitted(e2*, arrow), Target(rhs, tc2*)))
     with { CompNum:
       rules( CompNum: LabelComp(name, _) -> <CompNum> name ); // auto-unbox
       <CompList; map({?comp; rules( CompNum: comp -> 1 )})> arrow;
@@ -35,9 +35,6 @@ rules
   
 rules // components from lhs
 
-  // exp-label-comp-inits(|num) = 
-  //   map(exp-label-comp-init(|num))
-  
   exp-label-comp-init(|num):
     LabelComp(name, t) -> Formula(Match(VarRef(<get-sort-name; comp-var(|num)> name), t))
  

--- a/dynsem/trans/ds2ds/fuse-sections.str
+++ b/dynsem/trans/ds2ds/fuse-sections.str
@@ -16,7 +16,8 @@ rules
       natops-decl   := <collect-all(?NativeOperators(<id>)); concat; !NativeOperators(<id>)> body*;
       arrow-decl    := <collect-all(?ArrowDeclarations(<id>)); concat; !ArrowDeclarations(<id>)> body*;
       varschemes-decl := <collect-all(?VariableSchemes(<id>)); concat; !VariableSchemes(<id>)> body*;
-      signatures    := [ sort-decl, cons-decl, natcons-decl, natops-decl, arrow-decl, natty-decl, varschemes-decl ];
+      aliases-decl := <collect-all(?Aliases(<id>)); concat; !Aliases(<id>)> body*;
+      signatures    := [ sort-decl, cons-decl, natcons-decl, natops-decl, arrow-decl, natty-decl, varschemes-decl, aliases-decl ];
       rule-decl*    := <collect-all(?Rules(<id>)); concat; sort-rules> body*
   
   sort-rules = qsort((rule-con-name, rule-con-name); string-gt)

--- a/dynsem/trans/ds2ds/fuse-sections.str
+++ b/dynsem/trans/ds2ds/fuse-sections.str
@@ -10,18 +10,17 @@ rules
     with
       import        := <collect-all(?Imports(<id>)); concat; !Imports(<id>)> body*;
       sort-decl     := <collect-all(?Sorts(<id>)); concat; !Sorts(<id>)> body*;
-      semcomp-decl  := <collect-all(?SemanticComponents(<id>)); concat; !SemanticComponents(<id>)> body*;
       natty-decl    := <collect-all(?NativeDataTypes(<id>)); concat; !NativeDataTypes(<id>)> body*;
       cons-decl     := <collect-all(?Constructors(<id>)); concat; !Constructors(<id>)> body*;
       natcons-decl  := <collect-all(?NativeConstructors(<id>)); concat; !NativeConstructors(<id>)> body*;
       natops-decl   := <collect-all(?NativeOperators(<id>)); concat; !NativeOperators(<id>)> body*;
       arrow-decl    := <collect-all(?ArrowDeclarations(<id>)); concat; !ArrowDeclarations(<id>)> body*;
       varschemes-decl := <collect-all(?VariableSchemes(<id>)); concat; !VariableSchemes(<id>)> body*;
-      signatures    := [ sort-decl, cons-decl, semcomp-decl, natcons-decl, natops-decl, arrow-decl, natty-decl, varschemes-decl ];
+      signatures    := [ sort-decl, cons-decl, natcons-decl, natops-decl, arrow-decl, natty-decl, varschemes-decl ];
       rule-decl*    := <collect-all(?Rules(<id>)); concat; sort-rules> body*
   
   sort-rules = qsort((rule-con-name, rule-con-name); string-gt)
   
   rule-con-name =
     ?Rule(_, _, Relation(_, Source(Con(<id>, _), _), _, _)) <+ !""
-
+  

--- a/dynsem/trans/ds2ds/merge-rules.str
+++ b/dynsem/trans/ds2ds/merge-rules.str
@@ -17,7 +17,7 @@ imports
   ds2ds/sugar
   lib-ds/lib-match
 
-rules /* merge ovelapping rules */
+rules /* merge overlapping rules */
 
   merge-rules-in-module-top =
     log-timed(

--- a/dynsem/trans/lib-ds.str
+++ b/dynsem/trans/lib-ds.str
@@ -15,7 +15,11 @@ rules // utils for deterministic variable name generation
 
 rules // projections for sorts
   
-  get-sort-name = ?SortDecl(<id>) + ?SimpleSort(<id>) + ?ListSort(s); !$[L_[<get-sort-name> s]]
+  get-sort-name =
+    ?SortDecl(<id>)
+    + ?SimpleSort(<id>)
+    + ?ListSort(s); !$[L_[<get-sort-name> s]]
+    + ?MapSort(k-s, v-s); !$[L_[<get-sort-name> k-s]_[<get-sort-name> v-s]]
   
   get-listsort-elementname = ?ListSort(<get-sort-name>)
 

--- a/dynsem/trans/lib-ds.str
+++ b/dynsem/trans/lib-ds.str
@@ -15,8 +15,7 @@ rules // utils for deterministic variable name generation
 
 rules // projections for sorts
   
-  get-sort-name = ?SortDecl(<id>) + ?SemanticComponent(<id>, _)
-  get-sort-name = ?SimpleSort(<id>) + ?ListSort(s); !$[L_[<get-sort-name> s]]
+  get-sort-name = ?SortDecl(<id>) + ?SimpleSort(<id>) + ?ListSort(s); !$[L_[<get-sort-name> s]]
   
   get-listsort-elementname = ?ListSort(<get-sort-name>)
 

--- a/readme.md
+++ b/readme.md
@@ -13,9 +13,9 @@ Let's assume that your language is called *LANG*. Let's assume that the followin
       Expr
       V
 
-    semantic-components
-      Env -> Map<String, Int>
-      Sto -> Map<Int, V>
+    aliases
+      Env : Map<String, Int>
+      Sto : Map<Int, V>
 
     constructors
       Plus: Expr * Expr -> Expr
@@ -108,6 +108,27 @@ Note the following replacements in the above fragment:
 
 Once the project is built, an open program can be evaluated by invoking the ***Interpreter*** > ***Evaluate*** action. In the example above the evaluation will result in a term *R_Result_V(res, sto)* where *res* has sort *V* and *sto* is an ATerm representation of the *Sto* semantic component
 
+### Changenotes 17/07/2015
+
+- Eliminated `semantic-components` section
+- Maps can be declared and used everywhere
+- Implements a new signature sections `aliases` where sort aliases can be declared.
+
+#### Updating specifications
+
+Specification which have `semantic-components` sections to declare synonyms for maps will need to declare the maps differently. A specification section declaring `semantic-components` such as:
+
+```
+semantic-components
+  Env -> Map<String, Value>
+```
+
+should be rewritten to:
+
+```
+aliases
+  Env : Map<String, Value>
+```
 
 ### Changenotes 26/05/2015
 


### PR DESCRIPTION
### Changenotes 17/07/2015
- Eliminated `semantic-components` section
- Maps can be declared and used everywhere
- Implements a new signature sections `aliases` where sort aliases can be declared.
#### Updating specifications

Specification which have `semantic-components` sections to declare synonyms for maps will need to declare the maps differently. A specification section declaring `semantic-components` such as:

```
semantic-components
  Env -> Map<String, Value>
```

should be rewritten to:

```
aliases
  Env : Map<String, Value>
```
