### PR TITLE
Long and Float built-in types

### DIFF
--- a/dynsem/trans/analysis/analysis-rules.str
+++ b/dynsem/trans/analysis/analysis-rules.str
@@ -257,7 +257,7 @@ rules // type rules for match-sides
   
   type-check-match-num(|in-ty):
     Int(_) -> <type-coerce-full(id)> (in-ty, IntType())
-  
+
   type-check-match-num(|in-ty):
     Real(_) -> <type-coerce-full(id)> (in-ty, RealType())
   
@@ -475,8 +475,20 @@ rules
     (ListType(ty-from), ListType(ty-to)) -> ListType(<coerce-s> (ty-from, ty-to))
   
   type-coerce(coerce-s):
+    (IntType(), LongType()) -> LongType()
+
+  type-coerce(coerce-s):
+    (FloatType(), RealType()) -> RealType()
+
+  type-coerce(coerce-s):
+    (IntType(), FloatType()) -> FloatType()
+
+  type-coerce(coerce-s):
     (IntType(), RealType()) -> RealType()
-  
+
+  type-coerce(coerce-s):
+    (LongType(), RealType()) -> RealType()
+
   type-coerce(coerce-s):
     (MapType(a-k-ty, a-v-ty), MapType(t-k-ty, t-v-ty)) -> MapType(k-ty, v-ty)
     where

--- a/dynsem/trans/analysis/analysis-signatures.str
+++ b/dynsem/trans/analysis/analysis-signatures.str
@@ -22,6 +22,8 @@ rules /* store signatures */
   
   store-built-ins =
     <store-def(|Types())> IntType() => def-int; <store-prop(|SortKind(), def-int)> SystemSort()
+    ; <store-def(|Types())> LongType() => def-long; <store-prop(|SortKind(), def-long)> SystemSort()
+    ; <store-def(|Types())> FloatType() => def-float; <store-prop(|SortKind(), def-float)> SystemSort()
     ; <store-def(|Types())> RealType() => def-real; <store-prop(|SortKind(), def-real)> SystemSort()
     ; <store-def(|Types())> BoolType() => def-bool; <store-prop(|SortKind(), def-bool)> SystemSort()
     ; <store-def(|Types())> StringType() => def-str; <store-prop(|SortKind(), def-str)> SystemSort()

--- a/dynsem/trans/analysis/constructors.str
+++ b/dynsem/trans/analysis/constructors.str
@@ -28,6 +28,8 @@ signature
   
   constructors
     IntType: DynSemType
+    LongType: DynSemType
+    FloatType: DynSemType
     RealType: DynSemType
     BoolType: DynSemType
     StringType: DynSemType

--- a/dynsem/trans/analysis/lib-analysis.str
+++ b/dynsem/trans/analysis/lib-analysis.str
@@ -118,7 +118,11 @@ rules // type rewriting
       is-string
   
   derw-type: IntType() -> <derw-type> "Int"
+
+  derw-type: LongType() -> <derw-type> "Long"
   
+  derw-type: FloatType() -> <derw-type> "Float"
+
   derw-type: RealType() -> <derw-type> "Real"
   
   derw-type: BoolType() -> <derw-type> "Bool"
@@ -129,6 +133,12 @@ rules // type rewriting
 
   id-to-builtin-type:
     "Int" -> IntType()
+
+  id-to-builtin-type:
+    "Long" -> LongType()
+
+  id-to-builtin-type:
+    "Float" -> FloatType()
     
   id-to-builtin-type:
     "Real" -> RealType()

--- a/dynsem/trans/backend/java-backend/emit-atermconversion.str
+++ b/dynsem/trans/backend/java-backend/emit-atermconversion.str
@@ -71,6 +71,12 @@ rules
   	IntType() -> e |[ factory.makeInt(e) ]|
 
   ds2java-atermconversion-name(|e):
+  	LongType() -> e |[ factory.makeInt(e) ]|
+
+  ds2java-atermconversion-name(|e):
+  	FloatType() -> e |[ factory.makeReal(e) ]|
+
+  ds2java-atermconversion-name(|e):
   	RealType() -> e |[ factory.makeReal(e) ]|
 
   ds2java-atermconversion-name(|e):

--- a/dynsem/trans/backend/java-backend/emit-constructorclasses.str
+++ b/dynsem/trans/backend/java-backend/emit-constructorclasses.str
@@ -75,18 +75,31 @@ rules
 	      }
 	    ]|
     where
+      debug(!1);
     	x_consname := <ds2java-constr-classname> c;
+      debug(!2);
       c-def := <lookup-def(|Constructors())> c;
+      debug(!3);
       ConstructorType(c-c-ty*, c-ty) := <lookup-prop(|Type())> c-def
+      ;debug(!4)
     where
+      debug(!5);
       fdec* := <map-with-index(ds2java-fielddecl)> c-c-ty*;
+      debug(!6);
     	param0* := <map-with-index(ds2java-method-paramdecl)> c-c-ty*;
+      debug(!7);
     	bstm0* := <map-with-index(ds2java-fieldinit)> c-c-ty*;
+      debug(!8);
     	fget* := <map-with-index(ds2java-getter)> c-c-ty*;
+      debug(!9);
     	bstm1* := <map-with-index(ds2java-field-eq-check)> c-c-ty*;
+      debug(!10);
     	specializer* := <ds2java-specializer-method> c-c-ty*;
+      debug(!11);
     	exec* := <ds2java-execmethods(ds2java-supercall|rule*)> c;
+      debug(!12);
     	atermconvert := <ds2java-atermconversion-constructor> c
+      ;debug(!13)
   
   // generate equality check for a field that is of native type
   ds2java-field-eq-check:

--- a/dynsem/trans/backend/java-backend/emit-constructorclasses.str
+++ b/dynsem/trans/backend/java-backend/emit-constructorclasses.str
@@ -75,31 +75,18 @@ rules
 	      }
 	    ]|
     where
-      debug(!1);
     	x_consname := <ds2java-constr-classname> c;
-      debug(!2);
       c-def := <lookup-def(|Constructors())> c;
-      debug(!3);
       ConstructorType(c-c-ty*, c-ty) := <lookup-prop(|Type())> c-def
-      ;debug(!4)
     where
-      debug(!5);
       fdec* := <map-with-index(ds2java-fielddecl)> c-c-ty*;
-      debug(!6);
     	param0* := <map-with-index(ds2java-method-paramdecl)> c-c-ty*;
-      debug(!7);
     	bstm0* := <map-with-index(ds2java-fieldinit)> c-c-ty*;
-      debug(!8);
     	fget* := <map-with-index(ds2java-getter)> c-c-ty*;
-      debug(!9);
     	bstm1* := <map-with-index(ds2java-field-eq-check)> c-c-ty*;
-      debug(!10);
     	specializer* := <ds2java-specializer-method> c-c-ty*;
-      debug(!11);
     	exec* := <ds2java-execmethods(ds2java-supercall|rule*)> c;
-      debug(!12);
     	atermconvert := <ds2java-atermconversion-constructor> c
-      ;debug(!13)
   
   // generate equality check for a field that is of native type
   ds2java-field-eq-check:

--- a/dynsem/trans/backend/java-backend/lib-ds2java.str
+++ b/dynsem/trans/backend/java-backend/lib-ds2java.str
@@ -74,7 +74,25 @@ rules /* projections of types to names */
     else
       !"int"
     end
+
+  ds2java-sort-to-name(box-type) =
+    ?LongType();
+    if box-type
+    then
+      !"Long"
+    else
+      !"long"
+    end
   
+  ds2java-sort-to-name(box-type) =
+    ?FloatType();
+    if box-type
+    then
+      !"Float"
+    else
+      !"float"
+    end
+
   ds2java-sort-to-name(box-type) =
     ?RealType();
     if box-type


### PR DESCRIPTION
This adds support for built-in DynSem sorts _Long_ and _Float_ which are mapped to Java's _long_ and _float_.
