### PR TITLE
Change sort aliases syntax

### DIFF
--- a/dynsem/src-gen/completions/Signatures-esv.esv
+++ b/dynsem/src-gen/completions/Signatures-esv.esv
@@ -19,10 +19,10 @@ completions
     <ID:ID> " : " <Type:Type>  
 
 completions
-  completion template SignatureSection : "aliases " =
-    "aliases\n\t" (cursor) (blank)  
-  completion template AliasDecl : "ID : Type" =
-    <ID:ID> " : " <Type:Type>  
+  completion template SignatureSection : "sort aliases " =
+    "sort aliases\n\t" (cursor) (blank)  
+  completion template AliasDecl : "ID = Type" =
+    <ID:ID> " = " <Type:Type>  
 
 completions
   completion template SignatureSection : "constructors " =

--- a/dynsem/src-gen/pp/Signatures-pp.str
+++ b/dynsem/src-gen/pp/Signatures-pp.str
@@ -137,7 +137,7 @@ strategies
   prettyprint-SignatureSection :
     Aliases(t1__) -> [ H(
                          [SOpt(HS(), "0")]
-                       , [S("aliases")]
+                       , [S("sort aliases")]
                        )
                      , t1__'
                      ]
@@ -149,7 +149,7 @@ strategies
   prettyprint-AliasDecl :
     AliasDecl(t1__, t2__) -> [ H(
                                  [SOpt(HS(), "0")]
-                               , [t1__', S(" : "), t2__']
+                               , [t1__', S(" = "), t2__']
                                )
                              ]
     with t1__' := <pp-one-Z(prettyprint-ID)> t1__

--- a/dynsem/src-gen/syntax/Signatures.sdf
+++ b/dynsem/src-gen/syntax/Signatures.sdf
@@ -25,8 +25,8 @@ exports
     CONTENTCOMPLETE -> VariableScheme   {cons("COMPLETION-VariableScheme")}
 
   context-free syntax
-    "aliases" AliasDecl* -> SignatureSection {cons("Aliases")}
-    ID ":" Type          -> AliasDecl        {cons("AliasDecl")}
+    "sort" "aliases" AliasDecl* -> SignatureSection {cons("Aliases")}
+    ID "=" Type                 -> AliasDecl        {cons("AliasDecl")}
 
   context-free syntax
     CONTENTCOMPLETE -> SignatureSection {cons("COMPLETION-SignatureSection")}

--- a/dynsem/syntax/Signatures.sdf3
+++ b/dynsem/syntax/Signatures.sdf3
@@ -29,10 +29,10 @@ context-free syntax // variable schemes
 context-free syntax // variable schemes
   
   SignatureSection.Aliases = <
-    aliases
+    sort aliases
       <{AliasDecl "\n"}*>>
   
-  AliasDecl.AliasDecl = [[ID] : [Type]]
+  AliasDecl.AliasDecl = [[ID] = [Type]]
 
 context-free syntax // constructor declarations
 


### PR DESCRIPTION
This PR changes the syntax used to declare the type aliases.

The accepted syntax before was:

```
module semantics

signature
    sorts Y
    aliases
        X : Y
```

meaning the declaration of `X` as an alias for sort `Y`. 

The new syntax is:

```
module semantics

signature
    sorts Y
    sort aliases
        X = Y
```

Note the addition of the keyword `sort` to the section name so that the section name becomes `sort aliases`; note the replacement of the `:` by `=`. The semantics of the declaration remains unchanged.
