### PR TITLE
stop importing completions from old esv files

### DIFF
--- a/dynsem/editor/ds-Completions.esv
+++ b/dynsem/editor/ds-Completions.esv
@@ -1,9 +1,5 @@
 module ds-Completions
 
-imports
-
-  completions/ds-esv
-
 completions
                                                                    
   // This file is used to define content completion.               


### PR DESCRIPTION
We are going to stop generating ESV files from SDF3, therefore, this import breaks building the project. Since completion from ESV is not happening in Core anyway, this import can be removed.
