### PR TITLE
Pass InputStreams instead of Paths for the parse table and specification term

### DIFF
--- a/dynsem/trans/backend/interpreter/lang-entrypoint.str
+++ b/dynsem/trans/backend/interpreter/lang-entrypoint.str
@@ -17,10 +17,10 @@ rules /* language file. interpreter entry point */
       
       import java.io.IOException;
       import java.io.InputStream;
+      import java.io.FileInputStream;
+      import java.io.FileNotFoundException;
       import java.io.OutputStream;
       import java.io.PrintStream;
-      import java.nio.file.Path;
-      import java.nio.file.Paths;
       import java.util.concurrent.Callable;
       
       import org.metaborg.meta.lang.dynsem.interpreter.terms.ITerm;
@@ -63,12 +63,18 @@ rules /* language file. interpreter entry point */
         
         @Override
         public DynSemContext createDynSemContext(InputStream in, PrintStream out) {
-          return createDynSemContext(in, out, Paths.get(SPEC_FILE), Paths.get(PARSE_TABLE));
+          try {
+            InputStream specInput = new FileInputStream(SPEC_FILE);
+            InputStream parseTableInput = new FileInputStream(PARSE_TABLE);
+            return createDynSemContext(in, out, specInput, parseTableInput);
+          } catch (FileNotFoundException fnfex) {
+            throw new RuntimeException(fnfex);
+          }
         }
 
-        public DynSemContext createDynSemContext(InputStream in, PrintStream out, Path specPath, Path tablePath) {
+        public DynSemContext createDynSemContext(InputStream in, PrintStream out, InputStream specInput, InputStream parseTableInput) {
           return new DynSemContext(new ~x:$[[<LanguageName>]TermRegistry](),
-                      new x_ruleregistry(specPath), tablePath, in, out);  
+                      new x_ruleregistry(specInput), parseTableInput, in, out);
         }
       
         public static void main(String[] args) throws Exception {

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/DynSemContext.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/DynSemContext.java
@@ -2,7 +2,6 @@ package org.metaborg.meta.lang.dynsem.interpreter;
 
 import java.io.InputStream;
 import java.io.PrintStream;
-import java.nio.file.Path;
 
 import org.metaborg.meta.lang.dynsem.interpreter.nodes.building.ITermBuildFactory;
 import org.metaborg.meta.lang.dynsem.interpreter.nodes.matching.ITermMatchPatternFactory;
@@ -21,17 +20,17 @@ public class DynSemContext {
 
 	private DynSemPrimedRun primedRun;
 
-	public DynSemContext(ITermRegistry termRegistry, RuleRegistry ruleRegistry, Path parseTable) {
-		this(termRegistry, ruleRegistry, parseTable, System.in, System.out);
+	public DynSemContext(ITermRegistry termRegistry, RuleRegistry ruleRegistry, InputStream parseTableInput) {
+		this(termRegistry, ruleRegistry, parseTableInput, System.in, System.out);
 	}
 
-	public DynSemContext(ITermRegistry termRegistry, RuleRegistry ruleRegistry, Path parseTable, InputStream input,
+	public DynSemContext(ITermRegistry termRegistry, RuleRegistry ruleRegistry, InputStream parseTableInput, InputStream input,
 			PrintStream output) {
 		this.termRegistry = termRegistry;
 		this.ruleRegistry = ruleRegistry;
 		this.input = input;
 		this.output = output;
-		this.langParser = new DynSemLanguageParser(parseTable);
+		this.langParser = new DynSemLanguageParser(parseTableInput);
 	}
 
 	public DynSemLanguageParser getParser() {

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/DynSemLanguageParser.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/DynSemLanguageParser.java
@@ -1,10 +1,7 @@
 package org.metaborg.meta.lang.dynsem.interpreter;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Path;
 
 import org.apache.commons.io.IOUtils;
 import org.spoofax.interpreter.terms.IStrategoTerm;
@@ -20,11 +17,11 @@ import org.spoofax.terms.io.binary.TermReader;
 import com.oracle.truffle.api.source.Source;
 
 public class DynSemLanguageParser {
-	private Path parsetable;
+	private InputStream parsetableInput;
 	private SGLR parser;
 
-	public DynSemLanguageParser(Path parsetable) {
-		this.parsetable = parsetable;
+	public DynSemLanguageParser(InputStream parsetableInput) {
+		this.parsetableInput = parsetableInput;
 	}
 
 	public IStrategoTerm parse(Source src, String startSymbol) {
@@ -53,10 +50,10 @@ public class DynSemLanguageParser {
 
 	private ParseTable loadPT() {
 		TermFactory factory = new TermFactory();
-		try (InputStream stream = new FileInputStream(new File(parsetable.toUri()));) {
+		try {
 			TermReader termReader = new TermReader(factory);
-			IStrategoTerm parseTableTerm = termReader.parseFromStream(stream);
-
+			IStrategoTerm parseTableTerm = termReader.parseFromStream(parsetableInput);
+			parsetableInput.close();
 			return new ParseTable(parseTableTerm, factory);
 		} catch (Exception e) {
 			throw new RuntimeException(e);

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/rules/RuleRegistry.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/rules/RuleRegistry.java
@@ -1,8 +1,7 @@
 package org.metaborg.meta.lang.dynsem.interpreter.nodes.rules;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -16,14 +15,13 @@ import org.spoofax.terms.io.TAFTermReader;
 
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.source.Source;
 
 public class RuleRegistry {
 
 	private final Map<String, RuleRoot> rules = new HashMap<>();
 
-	public RuleRegistry(Path specPath) {
-		populate(this, specPath);
+	public RuleRegistry(InputStream specInput) {
+		populate(this, specInput);
 		init();
 	}
 
@@ -69,13 +67,13 @@ public class RuleRegistry {
 		return name + "/" + constr + "/" + arity;
 	}
 
-	private static void populate(RuleRegistry reg, Path specificationPath) {
+	private static void populate(RuleRegistry reg, InputStream specInput) {
 		try {
-			Source source = Source.fromFileName(specificationPath.toAbsolutePath().toString());
 			TAFTermReader reader = new TAFTermReader(new TermFactory());
 
 			IStrategoTerm topSpecTerm;
-			topSpecTerm = reader.parseFromStream(source.getInputStream());
+			topSpecTerm = reader.parseFromStream(specInput);
+			specInput.close();
 
 			IStrategoList rulesTerm = ruleListTerm(topSpecTerm);
 			for (IStrategoTerm ruleTerm : rulesTerm) {

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/test/java/org/metaborg/meta/lang/dynsem/interpreter/test/TestSpecLoad.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/test/java/org/metaborg/meta/lang/dynsem/interpreter/test/TestSpecLoad.java
@@ -1,8 +1,10 @@
 package org.metaborg.meta.lang.dynsem.interpreter.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
@@ -26,9 +28,8 @@ public class TestSpecLoad {
 		
 		assert (DummyDynSemLanguage.INSTANCE != null);
 		
-		RuleRegistry rreg = new RuleRegistry(specFile.toPath());
-
-
+		InputStream specInput = new FileInputStream(specFile);
+		RuleRegistry rreg = new RuleRegistry(specInput);
 		assertEquals(5, rreg.ruleCount());
 	}
 


### PR DESCRIPTION
This way the input sources for both the parse table and specification term are not bound to only regular files. For example, one might want to use input from a file inside a zip archive (e.g. a .jar).
