### PR TITLE
Add evaluate method accepting ATerms

### DIFF
--- a/dynsem/trans/backend/interpreter/lang-entrypoint.str
+++ b/dynsem/trans/backend/interpreter/lang-entrypoint.str
@@ -76,6 +76,7 @@ rules /* language file. interpreter entry point */
       import org.metaborg.meta.lang.dynsem.interpreter.nodes.rules.RuleRegistry;
       import org.metaborg.meta.lang.dynsem.interpreter.nodes.rules.RuleResult;
       import org.metaborg.meta.lang.dynsem.interpreter.terms.ITermTransformer;
+      import org.spoofax.interpreter.terms.IStrategoTerm;
 
       import ~x:<OptTopPackageName>.~x:$[[<OptLanguageName>]TermRegistry];
 
@@ -94,15 +95,24 @@ rules /* language file. interpreter entry point */
         }
 
         public static void main(String[] args) throws Exception {
-          RuleResult res = evaluateStatic(args[0], System.in, System.out, System.err);
+          RuleResult res = evaluate(args[0], System.in, System.out, System.err);
           System.out.println(res.result);
         }
 
-        public static RuleResult evaluateStatic(String programFile,
+        public static RuleResult evaluate(String programFile,
             InputStream inputStream, OutputStream outputStream,
             OutputStream errorStream) throws Exception {
-          return new x_entryPoint().evaluate(programFile, inputStream,
-                outputStream, errorStream);
+          return new x_entryPoint()
+                .getCallable(programFile, inputStream, outputStream, errorStream)
+                .call();
+        }
+
+        public static RuleResult evaluate(IStrategoTerm term,
+            InputStream inputStream, OutputStream outputStream,
+            OutputStream errorStream) throws Exception {
+          return new x_entryPoint()
+                .getCallable(term, inputStream, outputStream, errorStream)
+                .call();
         }
 
         public static IDynSemLanguageParser createParser() {


### PR DESCRIPTION
This method could be hooked into by e.g. a native Java Stratego strategy after desugaring/parsing. An example is paplj: https://github.com/MetaBorgCube/declare-your-language/blob/core/paplj/paplj.full/src/main/strategies/paplj/full/strategies/runprogram_0_0.java#L15.

Although the above example is still in the old format of dynsem, it gives an idea of how it can be done. In the new format of dynsem, one would add the interpreter project as a dependency to the language project, and then implement a strategy such as the one above. One would then call the static `evaluate` method of the generated entrypoint with the `IStrategoTerm` that is given as argument to the strategy.
