### PR TITLE
Make term transformer accessor public in entry point

### DIFF
--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/DynSemEntryPoint.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/DynSemEntryPoint.java
@@ -88,7 +88,7 @@ public abstract class DynSemEntryPoint {
 		return parser;
 	}
 
-	private ITermTransformer getTransformer() {
+	public ITermTransformer getTransformer() {
 		return transformer;
 	}
 


### PR DESCRIPTION
This one was forgotten to be made public like the other accessors.
