### PR TITLE
SpoofaxWithCore/134

### DIFF
--- a/org.metaborg.meta.lang.dynsem.interpreter/pom.xml
+++ b/org.metaborg.meta.lang.dynsem.interpreter/pom.xml
@@ -55,13 +55,19 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.4</version>
+			<version>2.5</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.11</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>annotations</artifactId>
+			<version>3.0.1</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>


### PR DESCRIPTION
got rid of jsr305, junit, hamcrest-core dependencies; upgraded commons dependencies
