### PR TITLE
Support for pairs/tuples

### DIFF
--- a/dynsem/syntax/Signatures.sdf3
+++ b/dynsem/syntax/Signatures.sdf3
@@ -54,7 +54,7 @@ context-free syntax // constructor declarations
 
   Type.SimpleSort = <<ID>>
   Type.ListSort = <List(<Type>)> 
-  Type.TupleSort = [([{Type ", "}+])]
+  Type.TupleSort = [([{Type " * "}+])]
   Type = [[MapType]]
     
   MapType.MapSort = [Map([Type],[Type])]

--- a/dynsem/trans/analysis/analysis-rules.str
+++ b/dynsem/trans/analysis/analysis-rules.str
@@ -562,6 +562,11 @@ rules
     where
       k-ty := <coerce-s> (a-k-ty, t-k-ty);
       v-ty := <coerce-s> (a-v-ty, t-v-ty)
+      
+  type-coerce(coerce-s):
+    (TupleType(a-ty*), TupleType(t-ty*)) -> TupleType(ty*)
+    where
+      ty* := <zip(coerce-s)> (a-ty*, t-ty*)
 
 rules /* support for implicit conversions */
   

--- a/dynsem/trans/analysis/lib-analysis.str
+++ b/dynsem/trans/analysis/lib-analysis.str
@@ -129,6 +129,9 @@ rules // type rewriting
     ListType(ty) -> ListSort(<derw-type> ty)
   
   derw-type:
+    TupleType(ty*) -> TupleSort(<map(derw-type)> ty*)
+  
+  derw-type:
     MapType(kty, vty) -> MapSort(<derw-type> kty, <derw-type> vty)
 
   derw-type:

--- a/dynsem/trans/backend/interpreter/desugar-for-interpreter.str
+++ b/dynsem/trans/backend/interpreter/desugar-for-interpreter.str
@@ -24,7 +24,7 @@ rules
     ; desugar-rec-tco
     ; desugar-unquote-strings
     ; desugar-nmatch-neq
-    ; resugar-lists
+    ; resugar-lists-tuples
 
 rules
 
@@ -218,7 +218,7 @@ rules /* unquote string literals */
   
 rules /* resugar list construction */
 
-  resugar-lists = innermost(resugar-list); innermost(add-typeanno-to-list)
+  resugar-lists-tuples = innermost(resugar-list); innermost(add-typeanno-to-list-tuples)
 
   resugar-list:
     Cast(Wld(), _) -> Wld()
@@ -232,29 +232,40 @@ rules /* resugar list construction */
   resugar-list:
     ListTail(h*, Cast(List([]), _)) -> List(h*)
   
-  add-typeanno-to-list:
+  add-typeanno-to-list-tuples:
     l@List(elems) -> TypedList(elems, list-class)
     where
       list-sort := <type-of; derw-type> l;
       list-class := <ds-to-interp-terms-types-name; qualify-term-class> list-sort
 
-  add-typeanno-to-list:
+  add-typeanno-to-list-tuples:
     l@ListTail(elems, tail) -> TypedListTail(elems, tail, list-class)
     where
       list-sort := <type-of; derw-type> l;
       list-class := <ds-to-interp-terms-types-name; qualify-term-class> list-sort 
   
-  add-typeanno-to-list:
+  add-typeanno-to-list-tuples:
     Cast(List([]), list-sort) -> TypedList([], <ds-to-interp-terms-types-name; qualify-term-class> list-sort)
   
-  add-typeanno-to-list:
+  add-typeanno-to-list-tuples:
     Formula(Match(List([]), rhs)) -> Formula(Match(TypedList([], list-class), rhs))
     where
       list-sort := <type-of; derw-type> rhs;
       list-class := <ds-to-interp-terms-types-name; qualify-term-class> list-sort
   
-  add-typeanno-to-list:
+  add-typeanno-to-list-tuples:
     LabelComp(list-sort, List([])) -> LabelComp(list-sort, TypedList([], list-class))
     where
-      list-class := <ds-to-interp-terms-types-name; qualify-term-class> list-sort 
+      list-class := <ds-to-interp-terms-types-name; qualify-term-class> list-sort
+  
+  add-typeanno-to-list-tuples:
+    tup@Tuple(t*) -> TypedTuple(t*, tuple-class)
+    where
+      debug(!"ty0");
+      tuple-sort := <debug(!"ty1"); type-of; debug(!"ty2"); derw-type; debug(!"ty3")> tup; 
+      debug(!"ty4");
+      tuple-class := <ds-to-interp-terms-types-name; qualify-term-class> tuple-sort
+      ;debug(!"ty5")
+
+
 

--- a/dynsem/trans/backend/interpreter/desugar-for-interpreter.str
+++ b/dynsem/trans/backend/interpreter/desugar-for-interpreter.str
@@ -261,11 +261,8 @@ rules /* resugar list construction */
   add-typeanno-to-list-tuples:
     tup@Tuple(t*) -> TypedTuple(t*, tuple-class)
     where
-      debug(!"ty0");
-      tuple-sort := <debug(!"ty1"); type-of; debug(!"ty2"); derw-type; debug(!"ty3")> tup; 
-      debug(!"ty4");
+      tuple-sort := <type-of; derw-type> tup; 
       tuple-class := <ds-to-interp-terms-types-name; qualify-term-class> tuple-sort
-      ;debug(!"ty5")
 
 
 

--- a/dynsem/trans/backend/interpreter/lang-ast.str
+++ b/dynsem/trans/backend/interpreter/lang-ast.str
@@ -9,31 +9,18 @@ imports
 rules
   
   ds-to-interp-terms-module =
-    debug(!5);
     ?Module(_, <fetch-elem(?Signatures(sig*))>);
-    debug(!6);
     where(ds-to-interp-clean-target; ds-to-interp-gen-project);
-    debug(!7);
     <ds-to-interp-terms-signatures-top; ds-to-interp-write-classes(|<get-opt> TermPkg())> sig*;
-    debug(!8);
     <ds-to-interp-terms-types-signatures; MkSingleton; ds-to-interp-write-classes(|<get-opt> TopPkg())> sig*;
-    debug(!9);
     <ds-to-inter-terms-sortbuilding; ds-to-interp-write-classes(|<get-opt> BuildPkg())> sig*;
-    debug(!10);
     <ds-to-interp-terms-building; ds-to-interp-write-classes(|<get-opt> BuildPkg())> sig*;
-    debug(!11);
     <ds-to-interp-terms-matching; ds-to-interp-write-classes(|<get-opt> MatchPkg())> sig*;
-    debug(!12);
     <ds-to-interp-nattypes-adapters-top; ds-to-interp-write-classes(|<get-opt> BuildPkg())> sig*;
-    debug(!13);
     <ds-to-interp-terms-registry-top; MkSingleton; ds-to-interp-write-classes(|<get-opt> TopPkg())> sig*;
-    debug(!14);
     ds-to-interp-language; MkSingleton; ds-to-interp-write-classes(|<get-opt> TopPkg());
-    debug(!15);
     ds-to-interp-language-entrypoint; MkSingleton; ds-to-interp-write-classes(|<get-opt> TopPkg());
-    debug(!16);
     ds-to-interp-language-benchmarkentry; MkSingleton; ds-to-interp-write-classes(|<get-opt> TopPkg())
-    ;debug(!17)
 
   ds-to-interp-clean-target =
     get-opt(|CleanProject()) <
@@ -46,23 +33,14 @@ rules /* Sort & Constructor classes */
   ds-to-interp-terms-signatures-top:
     sig* -> [sort-class*, cons-class*, tuple-class*, list-class*]
     where
-      debug(!"s1");
       sort-dec* := <fetch-elem(?Sorts(<id>))> sig*;
-      debug(!"s2");
       cons-dec* := <fetch-elem(?Constructors(<id>))> sig*;
-      debug(!"s3");
       list-dec* := <get-languagelist-usage-in-signatures> sig*;
-      debug(!"s4");
       tuple-dec* := <get-languagetuple-usage-in-signatures> sig*;
-      debug(!"s5");
       sort-class* := <map(ds-to-interp-terms-sortdecl(|cons-dec*))> sort-dec*;
-      debug(!"s6");
       cons-class* := <map(ds-to-interp-terms-consdecl)> cons-dec*;
-      debug(!"s7");
       tuple-class* := <map(ds-to-interp-terms-tupledecl)> tuple-dec*;
-      debug(!"s8");
       list-class* := <map(ds-to-interp-terms-listdecl)> list-dec*
-      ;debug(!"s9")
   
   get-languagelist-usage-in-signatures = collect-all(?ListSort(_)); nub
   
@@ -232,30 +210,18 @@ rules /* Sort & Constructor classes */
         }
       ]|
     where
-      debug(!"c1");
       x_classname := <ds-to-interp-terms-types-name> dec;
-      debug(!"c2");
       param0* := <ds-to-interp-sorts-to-params> kid*;
-      debug(!"c3");
       bstm0* := <ds-to-interp-sorts-to-finits> kid*;
-      debug(!"c4");
       fdec0* := <ds-to-interp-sorts-to-fdecs> kid*;
-      debug(!"c5");
       fget0* := <ds-to-interp-sorts-to-fgets> kid*;
-      debug(!"c6");
       e0* := <range; map(\ i -> e |[ ~x:<int-to-string; mkidx> ]| \)> (1, <length; inc> kid*);
-      debug(!"c7");
       e1* := <map-with-index((\ i -> e |[ term.getSubterm(~i:<dec; int-to-string>) ]| \, id); ds-to-interp-sorts-to-create-arg)> kid*;
-      debug(!"c8");
       bstm2* := <map-with-index(ds2java-field-eq-check)> kid*;
-      debug(!"c9");
       e_hash := <foldr(!e |[ new HashCodeBuilder() ]|, ds-to-interp-hashcode-append)> <range> (1, <length; inc> kid*)
-      ;debug(!"c10")
     where
-      debug(!"c11");
       if [] := kid*
       then
-        debug(!"c12");
         finit* := class-body-dec* |[
           public final static x_classname SINGLETON = new x_classname();
           private x_classname() {
@@ -266,9 +232,7 @@ rules /* Sort & Constructor classes */
             this.strategoTerm = strategoTerm;
           }
         ]|
-        ;debug(!"c13")
       else
-        debug(!"c14");
         finit* := class-body-dec* |[
           public x_classname(param0*) {
             this(e0*, null);
@@ -279,9 +243,7 @@ rules /* Sort & Constructor classes */
             this.strategoTerm = strategoTerm;
           }
         ]|
-        ;debug(!"c15")
       end
-      ;debug(!"c16")
   
   ds-to-interp-terms-tupledecl:
     srt@TupleSort(c-ty*) ->
@@ -382,27 +344,16 @@ rules /* Sort & Constructor classes */
         }
       ]|
     where
-      debug(!"t1");
       x_classname := <ds-to-interp-terms-types-name> srt;
-      debug(!"t2");
       param0* := <ds-to-interp-sorts-to-params> c-ty*;
-      debug(!"t3");
       bstm0* := <ds-to-interp-sorts-to-finits> c-ty*;
-      debug(!"t4");
       fdec0* := <ds-to-interp-sorts-to-fdecs> c-ty*;
-      debug(!"t5");
       fget0* := <ds-to-interp-sorts-to-fgets> c-ty*;
-      debug(!"t6");
       e0* := <range; map(\ i -> e |[ ~x:<int-to-string; mkidx> ]| \)> (1, <length; inc> c-ty*);
-      debug(!"t7");
       e1* := <map-with-index((\ i -> e |[ term.getSubterm(~i:<dec; int-to-string>) ]| \, id); ds-to-interp-sorts-to-create-arg)> c-ty*;
-      debug(!"t8");
       bstm2* := <map-with-index(ds2java-field-eq-check)> c-ty*;
-      debug(!"t9");
       e_hash := <foldr(!e |[ new HashCodeBuilder() ]|, ds-to-interp-hashcode-append)> <range> (1, <length; inc> c-ty*)
-      ;debug(!"t10")
     where
-      debug(!"t11");
       finit* := class-body-dec* |[
         public x_classname(param0*) {
           this(e0*, null);
@@ -413,7 +364,6 @@ rules /* Sort & Constructor classes */
           this.strategoTerm = strategoTerm;
         }
       ]|
-      ;debug(!"t12")
       
   ds-to-interp-hashcode-append:
     (idx, e) -> e |[ e.append(~x:$[_[idx]]) ]|

--- a/dynsem/trans/backend/interpreter/lang-ast.str
+++ b/dynsem/trans/backend/interpreter/lang-ast.str
@@ -792,12 +792,14 @@ rules /* term building */
       x_expectmethod := $[expect[x_sortclass]]
 
   ds-to-interp-terms-building:
-    sig* -> [con-build*, list-build*]
+    sig* -> [con-build*, list-build*, tuple-build*]
     where
       con-dec* := <fetch-elem(?Constructors(<id>))> sig*;
       list-dec* := <get-languagelist-usage-in-signatures> sig*;
+      tuple-dec* := <get-languagetuple-usage-in-signatures> sig*;
       con-build* := <map(ds-to-interp-terms-building-con)> con-dec*;
-      list-build* := <map(ds-to-interp-terms-building-list)> list-dec*
+      list-build* := <map(ds-to-interp-terms-building-list)> list-dec*;
+      tuple-build* := <map(ds-to-interp-terms-building-tuple)> tuple-dec*
 
   ds-to-interp-terms-building-con:
     dec@ConsDecl(_, kid*, s, _) ->
@@ -839,6 +841,41 @@ rules /* term building */
       else
         e_term := e |[ new x_termclass(e0*) ]|
       end
+
+  ds-to-interp-terms-building-tuple:
+    dec@TupleSort(s*) ->
+      compilation-unit |[
+        package ~x:<get-opt> BuildPkg();
+      
+        import ~x:$[[<get-opt> TermPkg()].*];
+        import ~x:<get-opt> NativePkg().*;
+        import org.metaborg.meta.lang.dynsem.interpreter.nodes.building.*;
+        import com.oracle.truffle.api.dsl.NodeChild;
+        import com.oracle.truffle.api.dsl.NodeChildren;
+        import com.oracle.truffle.api.dsl.Specialization;
+        import com.oracle.truffle.api.source.SourceSection;
+
+        @NodeChildren({ ~child* })
+        public abstract class x_class extends TermBuild {
+
+          public x_class(SourceSection source) {
+            super(source);
+          }
+          
+          @Specialization
+          public x_termclass doTyped(param0*) {
+            return e_term;
+          }
+          
+        }
+      ]|
+    where
+      x_class := $[[<ds-to-interp-terms-types-name> dec]Build];
+      child* := <ds-to-interp-terms-building-childannos> s*;
+      x_termclass := <ds-to-interp-terms-types-name> dec;
+      param0* := <ds-to-interp-terms-building-params> s*;
+      e0* := <ds-to-interp-terms-building-exprs> s*;
+      e_term := e |[ new x_termclass(e0*) ]|
 
   ds-to-interp-terms-building-childannos = map-with-index(ds-to-interp-terms-building-childanno)
   
@@ -914,12 +951,14 @@ rules /* term building */
 rules /* term matching */
 
   ds-to-interp-terms-matching:
-    sig* -> [con-match*, list-match*]
+    sig* -> [con-match*, list-match*, tuple-match*]
     where
       con-dec* := <fetch-elem(?Constructors(<id>))> sig*;
       list-dec* := <get-languagelist-usage-in-signatures> sig*;
+      tuple-dec* := <get-languagetuple-usage-in-signatures> sig*;
       con-match* := <map(ds-to-interp-terms-matching-con)> con-dec*;
-      list-match* := <map(ds-to-interp-terms-matching-list)> list-dec*
+      list-match* := <map(ds-to-interp-terms-matching-list)> list-dec*;
+      tuple-match* := <map(ds-to-interp-terms-matching-tuple)> tuple-dec*
 
   ds-to-interp-terms-matching-con:
     dec@ConsDecl(_, kid*, _, _) -> 
@@ -968,6 +1007,54 @@ rules /* term matching */
       param0* := <ds-to-interp-terms-matching-initparams> kid*;
       bstm0* := <ds-to-interp-terms-matching-finits> kid*;
       bstm1* := <foldr(![], ds-to-interp-terms-matching-matchdescend)> <range; reverse> (1, <length; inc> kid*)
+      
+  ds-to-interp-terms-matching-tuple:
+    dec@TupleSort(s*) -> 
+      compilation-unit |[
+        package ~x:<get-opt> MatchPkg();
+        
+        import ~x:<get-opt> TermPkg().x_termclass;
+        import ~x:<get-opt> NativePkg().*;
+        import org.metaborg.meta.lang.dynsem.interpreter.nodes.matching.MatchPattern;
+        import org.metaborg.meta.lang.dynsem.interpreter.nodes.matching.PatternMatchFailure;
+        
+        import com.oracle.truffle.api.dsl.Specialization;
+        import com.oracle.truffle.api.dsl.Fallback;
+        import com.oracle.truffle.api.frame.VirtualFrame;
+        import com.oracle.truffle.api.source.SourceSection;
+        
+        public abstract class x_matcherclass extends MatchPattern {
+        
+          ~fdec*
+        
+          public x_matcherclass(SourceSection source, param0*) {
+            super(source);
+            bstm0*
+          }
+        
+          @Specialization
+          public void doTyped(VirtualFrame frame, x_termclass term) {
+            bstm1*
+          }
+
+          @Fallback
+          public void doGeneric(VirtualFrame frame, Object term) {
+            if (term instanceof x_termclass) {
+              doTyped(frame, (x_termclass) term);
+            } else {
+              throw PatternMatchFailure.INSTANCE;
+            }
+          }
+          
+        }
+      ]|
+    where
+      x_termclass := <ds-to-interp-terms-types-name> dec;
+      x_matcherclass := $[[x_termclass]MatchPattern];
+      fdec* := <ds-to-interp-terms-matching-fdecs> s*; 
+      param0* := <ds-to-interp-terms-matching-initparams> s*;
+      bstm0* := <ds-to-interp-terms-matching-finits> s*;
+      bstm1* := <foldr(![], ds-to-interp-terms-matching-matchdescend)> <range; reverse> (1, <length; inc> s*)
       
   ds-to-interp-terms-matching-initparams = map-with-index(ds-to-interp-terms-matching-initparam)
   

--- a/dynsem/trans/backend/interpreter/lang-ast.str
+++ b/dynsem/trans/backend/interpreter/lang-ast.str
@@ -9,18 +9,31 @@ imports
 rules
   
   ds-to-interp-terms-module =
+    debug(!5);
     ?Module(_, <fetch-elem(?Signatures(sig*))>);
+    debug(!6);
     where(ds-to-interp-clean-target; ds-to-interp-gen-project);
+    debug(!7);
     <ds-to-interp-terms-signatures-top; ds-to-interp-write-classes(|<get-opt> TermPkg())> sig*;
+    debug(!8);
     <ds-to-interp-terms-types-signatures; MkSingleton; ds-to-interp-write-classes(|<get-opt> TopPkg())> sig*;
+    debug(!9);
     <ds-to-inter-terms-sortbuilding; ds-to-interp-write-classes(|<get-opt> BuildPkg())> sig*;
+    debug(!10);
     <ds-to-interp-terms-building; ds-to-interp-write-classes(|<get-opt> BuildPkg())> sig*;
+    debug(!11);
     <ds-to-interp-terms-matching; ds-to-interp-write-classes(|<get-opt> MatchPkg())> sig*;
+    debug(!12);
     <ds-to-interp-nattypes-adapters-top; ds-to-interp-write-classes(|<get-opt> BuildPkg())> sig*;
+    debug(!13);
     <ds-to-interp-terms-registry-top; MkSingleton; ds-to-interp-write-classes(|<get-opt> TopPkg())> sig*;
+    debug(!14);
     ds-to-interp-language; MkSingleton; ds-to-interp-write-classes(|<get-opt> TopPkg());
+    debug(!15);
     ds-to-interp-language-entrypoint; MkSingleton; ds-to-interp-write-classes(|<get-opt> TopPkg());
+    debug(!16);
     ds-to-interp-language-benchmarkentry; MkSingleton; ds-to-interp-write-classes(|<get-opt> TopPkg())
+    ;debug(!17)
 
   ds-to-interp-clean-target =
     get-opt(|CleanProject()) <
@@ -31,16 +44,29 @@ rules
 rules /* Sort & Constructor classes */
 
   ds-to-interp-terms-signatures-top:
-    sig* -> [sort-class*, cons-class*, list-class*]
+    sig* -> [sort-class*, cons-class*, tuple-class*, list-class*]
     where
+      debug(!"s1");
       sort-dec* := <fetch-elem(?Sorts(<id>))> sig*;
+      debug(!"s2");
       cons-dec* := <fetch-elem(?Constructors(<id>))> sig*;
+      debug(!"s3");
       list-dec* := <get-languagelist-usage-in-signatures> sig*;
+      debug(!"s4");
+      tuple-dec* := <get-languagetuple-usage-in-signatures> sig*;
+      debug(!"s5");
       sort-class* := <map(ds-to-interp-terms-sortdecl(|cons-dec*))> sort-dec*;
+      debug(!"s6");
       cons-class* := <map(ds-to-interp-terms-consdecl)> cons-dec*;
+      debug(!"s7");
+      tuple-class* := <map(ds-to-interp-terms-tupledecl)> tuple-dec*;
+      debug(!"s8");
       list-class* := <map(ds-to-interp-terms-listdecl)> list-dec*
+      ;debug(!"s9")
   
-  get-languagelist-usage-in-signatures = collect-all(?ListSort(_) /* ; not(is-builtin-type) */); nub
+  get-languagelist-usage-in-signatures = collect-all(?ListSort(_)); nub
+  
+  get-languagetuple-usage-in-signatures = collect-all(?TupleSort(_)); nub
   
   ds-to-interp-terms-sortdecl(|cons-dec*):
     dec@SortDecl(s) ->
@@ -182,7 +208,7 @@ rules /* Sort & Constructor classes */
                   }
                   if (fs.endsWith(", ")) fs = fs.substring(0, fs.length()-2);
               } catch (IllegalAccessException iaex) {
-                  System.err.println("<unreadalbe field>");
+                  System.err.println("<unreadable field>");
               }
               return CONSTRUCTOR + "_" + ARITY + "(" + fs + ")";
           }
@@ -206,18 +232,30 @@ rules /* Sort & Constructor classes */
         }
       ]|
     where
+      debug(!"c1");
       x_classname := <ds-to-interp-terms-types-name> dec;
+      debug(!"c2");
       param0* := <ds-to-interp-sorts-to-params> kid*;
+      debug(!"c3");
       bstm0* := <ds-to-interp-sorts-to-finits> kid*;
+      debug(!"c4");
       fdec0* := <ds-to-interp-sorts-to-fdecs> kid*;
+      debug(!"c5");
       fget0* := <ds-to-interp-sorts-to-fgets> kid*;
+      debug(!"c6");
       e0* := <range; map(\ i -> e |[ ~x:<int-to-string; mkidx> ]| \)> (1, <length; inc> kid*);
+      debug(!"c7");
       e1* := <map-with-index((\ i -> e |[ term.getSubterm(~i:<dec; int-to-string>) ]| \, id); ds-to-interp-sorts-to-create-arg)> kid*;
+      debug(!"c8");
       bstm2* := <map-with-index(ds2java-field-eq-check)> kid*;
+      debug(!"c9");
       e_hash := <foldr(!e |[ new HashCodeBuilder() ]|, ds-to-interp-hashcode-append)> <range> (1, <length; inc> kid*)
+      ;debug(!"c10")
     where
+      debug(!"c11");
       if [] := kid*
       then
+        debug(!"c12");
         finit* := class-body-dec* |[
           public final static x_classname SINGLETON = new x_classname();
           private x_classname() {
@@ -228,7 +266,9 @@ rules /* Sort & Constructor classes */
             this.strategoTerm = strategoTerm;
           }
         ]|
+        ;debug(!"c13")
       else
+        debug(!"c14");
         finit* := class-body-dec* |[
           public x_classname(param0*) {
             this(e0*, null);
@@ -239,7 +279,141 @@ rules /* Sort & Constructor classes */
             this.strategoTerm = strategoTerm;
           }
         ]|
+        ;debug(!"c15")
       end
+      ;debug(!"c16")
+  
+  ds-to-interp-terms-tupledecl:
+    srt@TupleSort(c-ty*) ->
+      compilation-unit |[
+        package ~x:<get-opt> TermPkg();
+        
+        import org.spoofax.interpreter.core.Tools;
+        import org.spoofax.interpreter.terms.*;
+        import ~x:<get-opt> NativePkg().*;
+        import ~x:<get-opt> TopPkg().TypesGen;
+        import org.metaborg.meta.lang.dynsem.interpreter.nodes.matching.ITermInstanceChecker;
+        import com.oracle.truffle.api.CompilerAsserts;
+        import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+        import java.lang.reflect.Field;
+        import org.apache.commons.lang3.builder.HashCodeBuilder;
+        import org.metaborg.meta.lang.dynsem.interpreter.terms.ITupleTerm;
+        
+        public final class x_classname implements ITupleTerm {
+
+          public final static int ARITY = ~i:<length; int-to-string> c-ty*;
+          private final IStrategoTerm strategoTerm;
+          
+          ~finit*
+
+          ~fdec0*
+
+          ~fget0*
+
+          public static x_classname create(IStrategoTerm term) {
+            CompilerAsserts.neverPartOfCompilation();
+            assert term != null;
+            assert Tools.isTermTuple(term);
+            assert term.getSubtermCount() == ARITY;
+            return new x_classname(e1*, term);
+          }
+          
+          @Override
+          public int size() {
+            return ARITY;
+          }
+          
+          @Override
+          public boolean equals(Object obj) {
+            if (this == obj)
+              return true;
+            if (obj == null)
+              return false;
+            if (getClass() != obj.getClass())
+              return false;
+            x_classname other = (x_classname) obj;
+            bstm2*
+            return true;
+          }
+          
+          @Override
+          public boolean hasStrategoTerm() {
+              return strategoTerm != null;
+          }
+          
+          @Override
+          public IStrategoTerm getStrategoTerm() {
+              return strategoTerm;
+          }
+          
+          @TruffleBoundary
+          @Override
+          public String toString() {
+              String fs = "";
+              try{
+                  for (Field f : getClass().getDeclaredFields()) {
+                      if (f.getName().startsWith("_")) {
+                          fs += f.get(this) + ", "; 
+                      }
+                  }
+                  if (fs.endsWith(", ")) fs = fs.substring(0, fs.length()-2);
+              } catch (IllegalAccessException iaex) {
+                  System.err.println("<unreadable field>");
+              }
+              return "(" + fs + ")";
+          }
+          
+          @Override
+          @TruffleBoundary
+          public int hashCode() {
+            return e_hash.toHashCode();
+          }
+          
+          @Override
+          public ITermInstanceChecker getCheck() {
+            return new ITermInstanceChecker() {
+        
+              @Override
+              public boolean isInstance(Object obj) {
+                return TypesGen.~x:$[is[x_classname]](obj);
+              }
+            };
+          }
+        }
+      ]|
+    where
+      debug(!"t1");
+      x_classname := <ds-to-interp-terms-types-name> srt;
+      debug(!"t2");
+      param0* := <ds-to-interp-sorts-to-params> c-ty*;
+      debug(!"t3");
+      bstm0* := <ds-to-interp-sorts-to-finits> c-ty*;
+      debug(!"t4");
+      fdec0* := <ds-to-interp-sorts-to-fdecs> c-ty*;
+      debug(!"t5");
+      fget0* := <ds-to-interp-sorts-to-fgets> c-ty*;
+      debug(!"t6");
+      e0* := <range; map(\ i -> e |[ ~x:<int-to-string; mkidx> ]| \)> (1, <length; inc> c-ty*);
+      debug(!"t7");
+      e1* := <map-with-index((\ i -> e |[ term.getSubterm(~i:<dec; int-to-string>) ]| \, id); ds-to-interp-sorts-to-create-arg)> c-ty*;
+      debug(!"t8");
+      bstm2* := <map-with-index(ds2java-field-eq-check)> c-ty*;
+      debug(!"t9");
+      e_hash := <foldr(!e |[ new HashCodeBuilder() ]|, ds-to-interp-hashcode-append)> <range> (1, <length; inc> c-ty*)
+      ;debug(!"t10")
+    where
+      debug(!"t11");
+      finit* := class-body-dec* |[
+        public x_classname(param0*) {
+          this(e0*, null);
+        }
+        
+        private x_classname(param0*, IStrategoTerm strategoTerm) {
+          bstm0*
+          this.strategoTerm = strategoTerm;
+        }
+      ]|
+      ;debug(!"t12")
       
   ds-to-interp-hashcode-append:
     (idx, e) -> e |[ e.append(~x:$[_[idx]]) ]|
@@ -412,6 +586,11 @@ rules /* Sort & Constructor classes */
     (e_term, ls@ListSort(_)) -> e |[ x_listclass.create(e_term) ]|
     where
       x_listclass := <ds-to-interp-terms-types-name> ls
+  
+  ds-to-interp-sorts-to-create-arg:
+    (e_term, ts@TupleSort(_)) -> e |[ x_tupleclass.create(e_term) ]|
+    where
+      x_tupleclass := <ds-to-interp-terms-types-name> ts
 
   ds-to-interp-sortelem-to-create-arg(|e_tmpelem):
     s@SimpleSort(_) -> e |[ x_elemclass.create(e_tmpelem) ]|
@@ -562,7 +741,7 @@ rules /* type system class */
         import org.metaborg.meta.lang.dynsem.interpreter.terms.*;
         import com.github.krukow.clj_ds.PersistentMap;
         
-        @TypeSystem({ ~type*, IApplTerm.class, ITerm.class, PersistentMap.class, String.class, int.class, boolean.class, Object[].class })
+        @TypeSystem({ ~type*, IApplTerm.class, ITupleTerm.class, ITerm.class, PersistentMap.class, String.class, int.class, boolean.class, Object[].class })
         public class Types {
           
         }
@@ -571,7 +750,8 @@ rules /* type system class */
       decl* := <filter(?Sorts(<id>) + ?Constructors(<id>) + ?NativeDataTypes(<id>)); concat;
         qsort(?(ConsDecl(_, _, _, _), SortDecl(_)) + ?(SortDecl(_), NativeBaseTypeDecl(_, _, _)) + ?(ConsDecl(_, _, _, _), NativeBaseTypeDecl(_, _, _)))> sig-sec*;
       list* := <get-languagelist-usage-in-signatures> sig-sec*;
-      ![decl*, list*];
+      tuple* := <get-languagetuple-usage-in-signatures> sig-sec*;
+      ![decl*, tuple*, list*];
       map(ds-to-interp-terms-types-name);
       map(!Lit(Class(ClassOrInterfaceType(TypeName(Id(<id>)), None())))); nub => type*
 

--- a/dynsem/trans/backend/interpreter/lang-names.str
+++ b/dynsem/trans/backend/interpreter/lang-names.str
@@ -49,6 +49,9 @@ rules
   
   ds-to-interp-terms-types-name:
     ListSort(s) -> $[List_[<ds-to-interp-terms-types-name; ds-utils-java-escape-id; string-replace(|".","_")> s]]
+  
+  ds-to-interp-terms-types-name:
+    TupleSort(s*) -> $[Tuple_[<map(ds-to-interp-terms-types-name; ds-utils-java-escape-id; string-replace(|".","_")); separate-by(|"_"); concat-strings> s*]]
 
   ds-box-java-type = try(internal-ds-box-java-type)
   

--- a/dynsem/trans/backend/interpreter/lang-termregistry.str
+++ b/dynsem/trans/backend/interpreter/lang-termregistry.str
@@ -46,6 +46,7 @@ rules /* term registry */
             bstm1*
             bstm2*
             bstm3*
+            bstm4*
           }
           
           @Override
@@ -119,11 +120,13 @@ rules /* term registry */
       decl* := <filter(?Constructors(<id>) + ?NativeOperators(<id>) + ?NativeDataTypes(<id>)); concat> sig*;
       (consdecl*, (natopdecl*, nattydecl*)) := <partition(?ConsDecl(_, _, _, _)); (id, partition(?NativeOpDecl(_, _, _)))> decl*;
       list-dec* := <get-languagelist-usage-in-signatures> sig*;
+      tuple-dec* := <get-languagetuple-usage-in-signatures> sig*;
       x_classname := $[[<get-opt> LangName()]TermRegistry]; 
       bstm0* := <ds-to-interp-terms-registry-inits> consdecl*;
       bstm1* := <ds-to-interp-natopterms-registry-inits> natopdecl*;
       bstm2* := <ds-to-interp-nattyterms-registry-inits> nattydecl*;
-      bstm3* := <ds-to-interp-lists-registry-inits> list-dec*
+      bstm3* := <ds-to-interp-lists-registry-inits> list-dec*;
+      bstm4* := <ds-to-interp-tuples-registry-inits> tuple-dec*
 
   ds-to-interp-terms-registry-inits = mapconcat(ds-to-interp-terms-registry-init)
   
@@ -156,6 +159,38 @@ rules /* term registry */
       x_termmatchNODEGEN := $[[x_termclass]MatchPatternNodeGen];
       e1* := <map-with-index(\ (i, s) -> e |[ children[~i:<dec; int-to-string> i] ]| \)> kid*;
       e2* := <map-with-index(\ (i, _) -> e |[ children[~i:<dec; int-to-string> i] ]| \)> kid*
+
+  ds-to-interp-tuples-registry-inits = mapconcat(ds-to-interp-tuples-registry-init)
+
+  ds-to-interp-tuples-registry-init:
+    dec@TupleSort(s*) ->
+      bstm* |[
+       builderFactories.put(x_conclass.class, new ITermBuildFactory() {
+    
+          @Override
+          public x_termbuildclass apply(SourceSection source,
+              TermBuild... children) {
+            return x_termbuildNODEGEN.create(source, e1*);
+          }
+        });
+
+        matcherFactories.put(x_conclass.class, new ITermMatchPatternFactory() {
+    
+          @Override
+          public MatchPattern apply(SourceSection source,
+              MatchPattern... children) {
+            return x_termmatchNODEGEN.create(source, e2*);
+          }
+        });
+      ]|
+    with
+      x_conclass := <ds-to-interp-terms-types-name> dec;
+      x_termbuildclass := $[[x_conclass]Build];
+      x_termbuildNODEGEN := $[[x_termbuildclass]NodeGen];
+      x_termclass := <ds-to-interp-terms-types-name> dec;
+      x_termmatchNODEGEN := $[[x_termclass]MatchPatternNodeGen];
+      e1* := <map-with-index(\ (i, s) -> e |[ children[~i:<dec; int-to-string> i] ]| \)> s*;
+      e2* := <map-with-index(\ (i, _) -> e |[ children[~i:<dec; int-to-string> i] ]| \)> s*
 
   ds-to-interp-lists-registry-inits = mapconcat(ds-to-interp-lists-registry-init)
   

--- a/dynsem/trans/backend/interpreter/main.str
+++ b/dynsem/trans/backend/interpreter/main.str
@@ -20,15 +20,10 @@ rules
       <ds-to-interp(|path, project-path, local-project-path)> ast
       
   ds-to-interp(|path, project-path, local-project-path) =
-    debug(!0);
     ds-to-interp-init-options(|path, local-project-path);
-    debug(!1);
     ds-to-interp-table;
-    debug(!2);
     ds-to-interp-specification(|path, project-path);
-    debug(!3);
     ds-to-interp-terms(|path, local-project-path)
-    ;debug(!4)
   
   ds-to-interp-specification(|path, project-path) =
     module-to-core(|path, project-path);

--- a/dynsem/trans/backend/interpreter/main.str
+++ b/dynsem/trans/backend/interpreter/main.str
@@ -20,10 +20,15 @@ rules
       <ds-to-interp(|path, project-path, local-project-path)> ast
       
   ds-to-interp(|path, project-path, local-project-path) =
+    debug(!0);
     ds-to-interp-init-options(|path, local-project-path);
+    debug(!1);
     ds-to-interp-table;
+    debug(!2);
     ds-to-interp-specification(|path, project-path);
+    debug(!3);
     ds-to-interp-terms(|path, local-project-path)
+    ;debug(!4)
   
   ds-to-interp-specification(|path, project-path) =
     module-to-core(|path, project-path);

--- a/dynsem/trans/backend/interpreter/signature.str
+++ b/dynsem/trans/backend/interpreter/signature.str
@@ -18,6 +18,8 @@ signature
     
     TypedList : List(Term) * String -> List
     TypedListTail : List(Term) * Term * String -> List
+
+    TypedTuple : Term * String -> Term
     
     Rule : List(Premise) * INFER * Relation * RuleKind * String -> Rule
     

--- a/dynsem/trans/lib-ds.str
+++ b/dynsem/trans/lib-ds.str
@@ -25,6 +25,7 @@ rules // projections for sorts
     + ?SimpleSort(<id>)
     + ?ListSort(s); !$[L_[<get-sort-name> s]]
     + ?MapSort(k-s, v-s); !$[L_[<get-sort-name> k-s]_[<get-sort-name> v-s]]
+    + ?TupleSort(s*); !$[T_[<map(get-sort-name); separate-by(|"_"); concat-strings> s*]]
   
 //  get-listsort-elementname = ?ListSort(<get-sort-name>)
 

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/building/TermBuild.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/building/TermBuild.java
@@ -110,6 +110,9 @@ public abstract class TermBuild extends DynSemNode {
 		if (Tools.hasConstructor(t, "TypedList", 2) || Tools.hasConstructor(t, "TypedListTail", 3)) {
 			return ListBuild.create(t, fd);
 		}
+		if(Tools.hasConstructor(t, "TypedTuple", 2)) {
+			return TupleBuild.create(t, fd);
+		}
 		if (Tools.hasConstructor(t, "NativeFunCall", 4)) {
 			return SortFunCallBuild.create(t, fd);
 		}

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/building/TupleBuild.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/building/TupleBuild.java
@@ -1,0 +1,57 @@
+package org.metaborg.meta.lang.dynsem.interpreter.nodes.building;
+
+import org.metaborg.meta.lang.dynsem.interpreter.nodes.rules.Rule;
+import org.metaborg.meta.lang.dynsem.interpreter.utils.InterpreterUtils;
+import org.metaborg.meta.lang.dynsem.interpreter.utils.SourceSectionUtil;
+import org.spoofax.interpreter.core.Tools;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoList;
+
+import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.frame.FrameDescriptor;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.source.SourceSection;
+
+public class TupleBuild extends TermBuild {
+
+	@Children private final TermBuild[] elemNodes;
+	private final Class<?> tupleClass;
+
+	public TupleBuild(SourceSection source, TermBuild[] elemNodes, Class<?> tupleClass) {
+		super(source);
+		this.elemNodes = elemNodes;
+		this.tupleClass = tupleClass;
+	}
+
+	@Override
+	public Object executeGeneric(VirtualFrame frame) {
+		CompilerDirectives.transferToInterpreterAndInvalidate();
+		final TermBuild concreteListBuild = InterpreterUtils
+				.notNull(getContext().getTermRegistry().lookupBuildFactory(tupleClass))
+				.apply(getSourceSection(), cloneNodes(elemNodes));
+		return replace(concreteListBuild).executeGeneric(frame);
+	}
+
+	public static TupleBuild create(IStrategoAppl t, FrameDescriptor fd) {
+		CompilerAsserts.neverPartOfCompilation();
+		assert Tools.hasConstructor(t, "TypedTuple", 2);
+
+		IStrategoList childrenT = Tools.listAt(t, 0);
+		TermBuild[] children = new TermBuild[childrenT.size()];
+		for (int i = 0; i < children.length; i++) {
+			children[i] = TermBuild.create(Tools.applAt(childrenT, i), fd);
+		}
+
+		String dispatchClassName = Tools.stringAt(t, 1).stringValue();
+		Class<?> dispatchClass;
+
+		try {
+			dispatchClass = Rule.class.getClassLoader().loadClass(dispatchClassName);
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException("Could not load dispatch class " + dispatchClassName);
+		}
+		return new TupleBuild(SourceSectionUtil.fromStrategoTerm(t), children, dispatchClass);
+	}
+
+}

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/matching/MatchPattern.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/matching/MatchPattern.java
@@ -40,6 +40,10 @@ public abstract class MatchPattern extends DynSemNode {
 			return GenericListMatch.create(t, fd);
 		}
 
+		if (Tools.hasConstructor(t, "TypedTuple", 2)) {
+			return TupleMatch.create(t, fd);
+		}
+
 		if (Tools.hasConstructor(t, "LabelComp", 2)) {
 			// TODO we should use the type information from the labelcomp instead of skipping over it
 			return MatchPattern.create(Tools.applAt(t, 1), fd);

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/matching/TupleMatch.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/matching/TupleMatch.java
@@ -1,0 +1,59 @@
+package org.metaborg.meta.lang.dynsem.interpreter.nodes.matching;
+
+import org.metaborg.meta.lang.dynsem.interpreter.nodes.rules.Rule;
+import org.metaborg.meta.lang.dynsem.interpreter.utils.InterpreterUtils;
+import org.metaborg.meta.lang.dynsem.interpreter.utils.SourceSectionUtil;
+import org.spoofax.interpreter.core.Tools;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoList;
+
+import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.frame.FrameDescriptor;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.source.SourceSection;
+
+public class TupleMatch extends MatchPattern {
+
+	@Children private final MatchPattern[] elemPatterns;
+	private final Class<?> tupleClass;
+
+	public TupleMatch(SourceSection source, MatchPattern[] elemPatterns, Class<?> tupleClass) {
+		super(source);
+		this.elemPatterns = elemPatterns;
+		this.tupleClass = tupleClass;
+	}
+
+	@Override
+	public void executeMatch(VirtualFrame frame, Object term) {
+		CompilerDirectives.transferToInterpreterAndInvalidate();
+		final MatchPattern concreteMatch = InterpreterUtils
+				.notNull(getContext().getTermRegistry().lookupMatchFactory(tupleClass))
+				.apply(getSourceSection(), cloneNodes(elemPatterns));
+
+		replace(concreteMatch).executeMatch(frame, term);
+	}
+
+	public static TupleMatch create(IStrategoAppl t, FrameDescriptor fd) {
+		CompilerAsserts.neverPartOfCompilation();
+		assert Tools.hasConstructor(t, "TypedTuple", 2);
+
+		IStrategoList childrenT = Tools.listAt(t, 0);
+		MatchPattern[] children = new MatchPattern[childrenT.size()];
+		for (int i = 0; i < children.length; i++) {
+			children[i] = MatchPattern.create(Tools.applAt(childrenT, i), fd);
+		}
+
+		final String dispatchClassName = Tools.stringAt(t, 1).stringValue();
+		Class<?> dispatchClass;
+
+		try {
+			dispatchClass = Rule.class.getClassLoader().loadClass(dispatchClassName);
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException("Could not load dispatch class " + dispatchClassName);
+		}
+
+		return new TupleMatch(SourceSectionUtil.fromStrategoTerm(t), children, dispatchClass);
+	}
+
+}

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/terms/ITupleTerm.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/terms/ITupleTerm.java
@@ -1,0 +1,14 @@
+/**
+ * 
+ */
+package org.metaborg.meta.lang.dynsem.interpreter.terms;
+
+/**
+ * Interface that all tuple terms must implement.
+ * 
+ * @author vladvergu
+ *
+ */
+public interface ITupleTerm extends ITerm {
+
+}


### PR DESCRIPTION
This implements support for tuples in DynSem. Example:

```
signature
  constructors
    ClosV: (String * Exp * Env) -> V

rules
  E |- Fun(x, e) --> ClosV((x, e, E)).

  App(ClosV((x, e, E)), v1) --> v2
  where
    E  |- bindVar(x, v1) --> E';
    E' |- e --> v2.
```
