### PR TITLE
Integrate SL as regression tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,1 +1,4 @@
 
+[submodule "metaborg-sl"]
+	path = metaborg-sl
+	url = https://github.com/MetaBorgCube/metaborg-sl

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,9 @@ before_script:
   - echo "MAVEN_OPTS='-server -Xms512m -Xmx1024m -Xss16m'" > ~/.mavenrc
 script: ./travis-build.sh
 
+cache:
+ directories:
+   - $HOME/.m2
+
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,5 @@ before_script:
   - echo "MAVEN_OPTS='-server -Xms512m -Xmx1024m -Xss16m'" > ~/.mavenrc
 script: ./travis-build.sh
 
-cache:
- directories:
-   - $HOME/.m2
-
 jdk:
   - oraclejdk8

--- a/dynsem/trans/analysis/analysis-rules.str
+++ b/dynsem/trans/analysis/analysis-rules.str
@@ -51,9 +51,7 @@ rules /* syntactic checks */
 rules /* store variables */
   
   store-rules-all =
-    with(init-hitcount);
-    alltd(store-rules);
-    log-hitcount
+    alltd(store-rules)
   
   store-rules =
     Rules(with(prime-typaths); map(store-rule <+ where(add-msg(|Error(), <id>, $[Rule could not be type checked. This is a bug, please report it.]))))
@@ -693,13 +691,11 @@ rules /* support for implicit conversions */
     where
       <MemoTyPath> t => ans
       <
-        hit;
         if <?[_ | _]> ans
         then
           path* := ans
         end // in the else case, we have a cached failure and we fail by not binding path*
       +
-        miss;
         if <get-typath(coerce-strategy)> t => path*
         then
           rules(
@@ -789,24 +785,3 @@ rules /* utilities */
     rules(AntiCycle:+ t -> t);
     s
   |}
-
-  init-hitcount = rules(HitStats: _ -> (0, 0))
-  
-  get-hitcount = HitStats
-  
-  log-hitcount = 
-    where(
-      get-hitcount => (hits, misses);
-      <concat-strings> [ <align-left> (' ', "Memoization efficiency", 27), " : [hits/misses] = [", <int-to-string> hits, "/", <int-to-string> misses, "]" ];
-      log(|Info(),<id>)
-    )
-  
-  hit =
-    HitStats => (hits, misses);
-    hits' := <inc> hits;
-    rules(HitStats: _ -> (hits', misses)) 
-
-  miss =
-    HitStats => (hits, misses);
-    misses' := <inc> misses;
-    rules(HitStats: _ -> (hits, misses'))

--- a/dynsem/trans/analysis/main.str
+++ b/dynsem/trans/analysis/main.str
@@ -59,33 +59,19 @@ strategies // analysis workhorse
 
   analyze-module =
     desugar-top;
-    log-timed(mark-vars| "Marking variable def sites");
-    log-timed(rename-all| "Renaming variables");
-    log-timed(store-all| "Storing all definitions")
+    mark-vars;
+    rename-all;
+    store-all
   
   store-all:
     m@Module(n, section*) -> m
     with
-      log-timed(
-        log-timed(
-          store-built-ins | "Storing built-in signatures"
-        );
-        log-timed(
-          <map(try(store-signatures))> section* | "Storing signatures"
-        );
-        log-timed(
-          <check-signatures> m | "Checking signatures" 
-        );
-        log-timed(
-          <store-rules-all> section* | "Storing rules"
-        );
-        log-timed(
-          <post-analysis-checks> m | "Post-analysis checks"
-        );
-        log-timed(
-          <gen-implicit-info-top> m | "Implicit conversion info"
-        )
-      | "Analysis" )
+      store-built-ins;
+      <map(try(store-signatures))> section*;
+      <check-signatures> m;
+      <store-rules-all> section*;
+      <post-analysis-checks> m;
+      <gen-implicit-info-top> m
 
 strategies // import resolution
 

--- a/dynsem/trans/backend/interpreter/main.str
+++ b/dynsem/trans/backend/interpreter/main.str
@@ -29,9 +29,11 @@ rules
   
   ds-to-interp(|path, project-path, local-project-path) =
     ds-to-interp-init-options(|path, local-project-path);
-    ds-to-interp-table;
-    ds-to-interp-specification(|path, project-path); ds-to-interp-specification-write;
-    ds-to-interp-terms(|path, local-project-path)
+    log-timed(
+      ds-to-interp-table;
+      ds-to-interp-specification(|path, project-path); ds-to-interp-specification-write;
+      ds-to-interp-terms(|path, local-project-path)
+    |$[Generating interpreter at: [<get-opt> GenProject()]])
   
   ds-to-interp-specification(|path, project-path) =
     module-to-core(|path, project-path);

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -7,4 +7,6 @@ mvn -Pstandalone install
 cd $TRAVIS_BUILD_DIR/org.metaborg.meta.lang.dynsem.interpreter
 mvn -Pstandalone test
 cd $TRAVIS_BUILD_DIR/metaborg-sl/org.metaborg.lang.sl
-mvn -Pstandalone verify
+mvn -Pstandalone test
+cd $TRAVIS_BUILD_DIR/metaborg-sl/org.metaborg.lang.sl.interpreter
+mvn -Pstandalone test

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -6,3 +6,5 @@ cd $TRAVIS_BUILD_DIR/dynsem2coq
 mvn -Pstandalone install
 cd $TRAVIS_BUILD_DIR/org.metaborg.meta.lang.dynsem.interpreter
 mvn -Pstandalone test
+cd $TRAVIS_BUILD_DIR/metaborg-sl/org.metaborg.lang.sl
+mvn verify

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -7,4 +7,4 @@ mvn -Pstandalone install
 cd $TRAVIS_BUILD_DIR/org.metaborg.meta.lang.dynsem.interpreter
 mvn -Pstandalone test
 cd $TRAVIS_BUILD_DIR/metaborg-sl/org.metaborg.lang.sl
-mvn verify
+mvn -Pstandalone verify

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -8,5 +8,5 @@ cd $TRAVIS_BUILD_DIR/org.metaborg.meta.lang.dynsem.interpreter
 mvn -Pstandalone test
 cd $TRAVIS_BUILD_DIR/metaborg-sl/org.metaborg.lang.sl
 mvn -Pstandalone test
-cd $TRAVIS_BUILD_DIR/metaborg-sl/org.metaborg.lang.sl.interpreter
+cd $TRAVIS_BUILD_DIR/metaborg-sl/org.metaborg.lang.sl.interp
 mvn -Pstandalone test


### PR DESCRIPTION
Integrate SL as regressions tests in Travis CI build. To achieve this SL has become a submodule in DynSem. Other modifications where required in the TransformMojo of spoofax-maven. We can merge this PR as soon as the Travis CI build starts succeeding (we have to wait for the Maven artifact cache to expire).

In addition to hooking up SL this PR includes a few changes to reduce the console spam produced during static analysis of DynSem specifications.