### PR TITLE
Multi-binds with guards

### DIFF
--- a/dynsem/editor/Main.esv
+++ b/dynsem/editor/Main.esv
@@ -11,9 +11,6 @@ language
                         
   extensions : ds
   
-  table         : target/metaborg/sdf.tbl
-  start symbols : Module
-  
   provider : target/metaborg/stratego.jar
   provider : target/metaborg/stratego-javastrat.jar
 

--- a/dynsem/editor/Syntax.esv
+++ b/dynsem/editor/Syntax.esv
@@ -2,6 +2,9 @@ module Syntax
 
 language
 
+  table         : target/metaborg/sdf-new.tbl
+  start symbols : Module
+
   line comment  : "//"
   block comment : "/*" * "*/"
 

--- a/dynsem/metaborg.yaml
+++ b/dynsem/metaborg.yaml
@@ -42,7 +42,13 @@ pardonedLanguages:
 - SDF
 build:
  useBuildSystemSpec: true
+ 
 language:
+  sdf:
+    # If set to java, set the table in editor/Syntax.esv to target/metaborg/sdf-new.tbl
+    sdf2table: java
+    placeholder:
+      prefix: "$"
   stratego:
     format: jar
     args:

--- a/dynsem/syntax/ds.sdf3
+++ b/dynsem/syntax/ds.sdf3
@@ -30,7 +30,6 @@ context-free syntax // rules
   ]
   
   Premise.Formula = [[Formula]]
-  Premise.AllFail = <all-fail> {deprecated}
 
   Premise.CaseMatch = [
     case [Term] of {
@@ -41,8 +40,6 @@ context-free syntax // rules
   Premise.GuardedBind = [
     [Term] as [{GuardedValue "\n or"}+]
   ]
-  
-  
   
   GuardedValue.GValue = [[Term] if [Term]]
   GuardedValue.NegGValue = [[Term] if not [Term]]
@@ -102,8 +99,6 @@ context-free syntax // formulas
   
   Formula = [[Relation]]
   Relation.Relation = [[Reads][Source] [Rel] [Target]]
-  
-  Formula.IsValue  = [value([Term])]
   
   Reads.NoReads = []
   Reads.Reads   = [[{LabelComp ", "}+] |- ]

--- a/dynsem/syntax/ds.sdf3
+++ b/dynsem/syntax/ds.sdf3
@@ -39,8 +39,10 @@ context-free syntax // rules
   ]
   
   Premise.GuardedBind = [
-    [Var] as [{GuardedValue "\n or"}+]
+    [Term] as [{GuardedValue "\n or"}+]
   ]
+  
+  
   
   GuardedValue.GValue = [[Term] if [Term]]
   GuardedValue.NegGValue = [[Term] if not [Term]]

--- a/dynsem/syntax/ds.sdf3
+++ b/dynsem/syntax/ds.sdf3
@@ -142,6 +142,7 @@ context-free syntax // terms
   Term.ListTail = <[ <{Term ", "}*> | <Term> ]>
   Term.ListLength = <|<Term>|>
   Term.Concat   = [[Term] ++ [Term]] {left}
+  Term.Reverse  = [`[Term]] {left}
   
   Term.TermPlaceholder = <???>
   

--- a/dynsem/syntax/ds.sdf3
+++ b/dynsem/syntax/ds.sdf3
@@ -162,7 +162,7 @@ context-free syntax // terms
   
   Term.MapHas = <<Term>[<Term>?]>
   Term.MapExtend = [[Term] + [Term]] {left}
-//  Term.MapUnbind = [[Term] \ [Term]] {assoc}
+  Term.MapUnbind = [[Term] \ [Term]] {left}
 
   Term.MapKeys = [allkeys([Term])]
   Term.MapValues = [allvalues([Term])]

--- a/dynsem/syntax/ds.sdf3
+++ b/dynsem/syntax/ds.sdf3
@@ -38,6 +38,14 @@ context-free syntax // rules
     }
   ]
   
+  Premise.GuardedBind = [
+    [Var] as [{GuardedValue "\n or"}+]
+  ]
+  
+  GuardedValue.GValue = [[Term] if [Term]]
+  GuardedValue.NegGValue = [[Term] if not [Term]]
+  GuardedValue.UValue = Term
+  
   Case.CasePattern = [
     [Term] =>
       [{Premise ";\n"}*]
@@ -74,6 +82,12 @@ context-free syntax // rules
   ID = <otherwise> {reject}
   ID = <semantic> {reject}
   ID = <components> {reject}
+  ID = <case> {reject}
+  ID = <as> {reject}
+  ID = <or> {reject}
+  ID = <if> {reject}
+  ID = <not> {reject}
+  
 
 context-free syntax // formulas
 

--- a/dynsem/trans/analysis/analysis-rules.str
+++ b/dynsem/trans/analysis/analysis-rules.str
@@ -566,8 +566,6 @@ rules
     where
       <type-check-build-expect(|BoolType())> ct
   
-  type-check-premise = ?AllFail()
-
   type-check-case(|in-ty):
     c@CaseOtherwise(prem*) -> c
     with

--- a/dynsem/trans/analysis/analysis-rules.str
+++ b/dynsem/trans/analysis/analysis-rules.str
@@ -287,6 +287,13 @@ rules
       map2-ty@MapType(_, _) := <type-check-build; try(get-alias-base)> map2
 
   type-check-build-map:
+    MapUnbind(map-t, key-t) -> map-ty
+    where
+      map-ty@MapType(m-key-ty, _) := <type-check-build; try(get-alias-base)> map-t;
+      key-ty := <type-check-build; try(get-alias-base)> key-t;
+      <type-coerce-full(fail)> (key-ty, m-key-ty)
+
+  type-check-build-map:
     DeAssoc(m-t, k-t) -> val-ty
     where
       map-ty@MapType(f-key-ty, val-ty) := <type-check-build> m-t;

--- a/dynsem/trans/analysis/analysis-rules.str
+++ b/dynsem/trans/analysis/analysis-rules.str
@@ -459,7 +459,7 @@ rules // type rules for match-sides
   type-check-match-tuple(|in-ty):
     ty@Tuple(t*) -> TupleType(<zip(type-check-match-wrap)> (f-ty*, t*))
     where
-      TupleType(f-ty*) := in-ty
+      TupleType(f-ty*) := <get-alias-base> in-ty
 
   type-check-match-tuple(|in-ty):
     Tuple(t*) -> TupleType(<map(type-check-match(|in-ty))> t*)

--- a/dynsem/trans/analysis/analysis-rules.str
+++ b/dynsem/trans/analysis/analysis-rules.str
@@ -546,7 +546,26 @@ rules
     with
       in-ty := <type-check-build> tb;
       <map(type-check-case(|in-ty))> case*
-      
+  
+  type-check-premise:
+    f@GuardedBind(v, guarded-value*) -> f
+    where
+      <map(try(type-check-guarded-value(|v)))> guarded-value*;
+      if (_, [_|_]) := <split-fetch(?UValue(_))> guarded-value*
+      then
+        add-msg(|Warning(), guarded-value*, $[Contains unreachble assignments])
+      end
+  
+  type-check-guarded-value(|v):
+    UValue(t) -> <type-check-premise> Formula(Match(t, v))
+  
+  type-check-guarded-value(|v):
+    guarded-value -> <type-check-premise> Formula(Match(t, v))
+    where
+      ?GValue(t, ct) + ?NegGValue(t, ct)
+    where
+      ct-ty := <type-check-build> ct;
+      <type-coerce-full(fail)> (ct-ty, BoolType())
   
   type-check-premise = ?AllFail()
 

--- a/dynsem/trans/analysis/analysis-rules.str
+++ b/dynsem/trans/analysis/analysis-rules.str
@@ -560,12 +560,11 @@ rules
     UValue(t) -> <type-check-premise> Formula(Match(t, v))
   
   type-check-guarded-value(|v):
-    guarded-value -> <type-check-premise> Formula(Match(t, v))
+    guarded-value -> <type-check-premise-top> Formula(Match(t, v))
     where
       ?GValue(t, ct) + ?NegGValue(t, ct)
     where
-      ct-ty := <type-check-build> ct;
-      <type-coerce-full(fail)> (ct-ty, BoolType())
+      <type-check-build-expect(|BoolType())> ct
   
   type-check-premise = ?AllFail()
 

--- a/dynsem/trans/analysis/analysis-rules.str
+++ b/dynsem/trans/analysis/analysis-rules.str
@@ -268,6 +268,11 @@ rules
       ty1@ListType(_) := <type-check-build> t1;
       ty2@ListType(_) := <type-check-build> t2
   
+  type-check-build-list:
+    Reverse(t) -> ty
+    where
+      ty@ListType(_) := <type-check-build; get-alias-base> t
+  
   type-check-build-tuple:
     Tuple(t*) -> TupleType(<map(type-check-build)> t*)
 

--- a/dynsem/trans/analysis/info-implicit-conversions.str
+++ b/dynsem/trans/analysis/info-implicit-conversions.str
@@ -152,6 +152,14 @@ rules
       MapType(f-key-ty, _) := <gen-implicit-info-type-of(is-matching); get-alias-base> map-t;
       a-key-ty := <gen-implicit-info-type-of(is-matching)> key-t;
       <gen-implicit-info-fact(is-matching|key-t)> (a-key-ty, f-key-ty)
+  
+  gen-implicit-info-term(is-matching):
+    MapUnbind(map, key) -> <fail>
+    where not(is-matching)
+    where
+      MapType(f-key-ty, _) := <gen-implicit-info-type-of(is-matching); get-alias-base> map;
+      a-key-ty := <gen-implicit-info-type-of(is-matching)> key;
+      <gen-implicit-info-fact(is-matching|key)> (a-key-ty, f-key-ty)
 
   gen-implicit-info-fact(is-matching|on-term) =
     (is-matching < Swap + id);

--- a/dynsem/trans/analysis/info-implicit-conversions.str
+++ b/dynsem/trans/analysis/info-implicit-conversions.str
@@ -121,7 +121,9 @@ rules
 
   // list index access
   gen-implicit-info-term(is-matching):
-    DeAssoc(map-t, key-t) -> <fail>
+    deassoc-like -> <fail>
+    where
+      ?DeAssoc(map-t, key-t) + ?MapHas(map-t, key-t)
     where
       MapType(f-key-ty, _) := <gen-implicit-info-type-of(is-matching); get-alias-base> map-t;
       a-key-ty := <gen-implicit-info-type-of(is-matching)> key-t;

--- a/dynsem/trans/analysis/info-implicit-conversions.str
+++ b/dynsem/trans/analysis/info-implicit-conversions.str
@@ -81,6 +81,30 @@ rules
       ArrowType(dec-lhs-ty, _) := <resolve-applicable-arrow-callsite; lookup-prop(|Type())> (arrow-name, lhs-ty);
       <gen-implicit-info-fact(fail|lhs)> (lhs-ty, dec-lhs-ty)
   
+  gen-implicit-info-premise:
+    GuardedBind(rhs, guarded-value*) -> <fail>
+    where
+      rhs-ty := <gen-implicit-info-type-of(fail)> rhs;
+      <filter(gen-implicit-info-guardedvalue(|rhs, rhs-ty))> guarded-value*
+  
+  gen-implicit-info-guardedvalue(|rhs, rhs-ty):
+    guarded-value -> <fail>
+    where
+      ?GValue(_, ct) + ?NegGValue(_, ct)
+    where
+    <gen-implicit-info(fail)> ct;
+      ct-ty := <gen-implicit-info-type-of(fail); get-alias-base> ct;
+      <gen-implicit-info-fact(fail|ct)> (ct-ty, BoolType())
+  
+  gen-implicit-info-guardedvalue(|rhs, rhs-ty):
+    guarded-value -> <fail>
+    where
+      ?GValue(t, _) + ?NegGValue(t, _) + ?UValue(t)
+    where
+      <gen-implicit-info(fail)> t;
+      t-ty := <gen-implicit-info-type-of(fail); get-alias-base> t;
+      <gen-implicit-info-fact(fail|rhs)> (t-ty, rhs-ty)
+  
   gen-implicit-info(is-matching) = alltd(gen-implicit-info-term(is-matching))
 
   gen-implicit-info-term(is-matching):

--- a/dynsem/trans/analysis/mark-references.str
+++ b/dynsem/trans/analysis/mark-references.str
@@ -44,6 +44,7 @@ rules
   	<+ As(make-vars, make-vars)
   	<+ CasePattern(make-vars, mark-vardefs-in-premise)
   	<+ CaseOtherwise(mark-vardefs-in-premise)
+  	<+ GuardedBind(make-vars, id)
 
   make-vars =
   	alltd(origin-track-forced(\ VarRef(x) -> Var(x) \))

--- a/dynsem/trans/backend/interpreter/desugar-for-interpreter.str
+++ b/dynsem/trans/backend/interpreter/desugar-for-interpreter.str
@@ -256,6 +256,11 @@ rules /* resugar list construction */
       list-sort := <type-of; derw-type> rhs
   
   add-typeanno-to-list-tuples:
+    Formula(Match(lhs, tup@Tuple(_))) -> Formula(Match(lhs, Cast(tup, tuple-sort)))
+    where
+      tuple-sort := <type-of; derw-type> lhs
+  
+  add-typeanno-to-list-tuples:
     LabelComp(Label(l), List([])) -> LabelComp(Label(l), Cast(List([]), list-sort))
     where
       list-sort := <lookup-def(|Components()); lookup-prop(|Type()); derw-type> l

--- a/dynsem/trans/backend/interpreter/desugar-for-interpreter.str
+++ b/dynsem/trans/backend/interpreter/desugar-for-interpreter.str
@@ -226,7 +226,7 @@ rules /* unquote string literals */
   
 rules /* resugar list construction */
 
-  resugar-lists-tuples = innermost(resugar-list); innermost(add-typeanno-to-list-tuples)
+  resugar-lists-tuples = innermost(resugar-list); bottomup(try(add-typeanno-to-list-tuples)); innermost(list-to-typedlist)
 
   resugar-list:
     Cast(Wld(), _) -> Wld()
@@ -241,60 +241,61 @@ rules /* resugar list construction */
     ListTail(h*, Cast(List([]), _)) -> List(h*)
   
   add-typeanno-to-list-tuples:
-    l@List(elems) -> TypedList(elems, list-class)
+    l@List(elems) -> Cast(List(elems), list-sort)
     where
-      list-sort := <type-of; derw-type> l;
-      list-class := <ds-to-interp-terms-types-name; qualify-term-class> list-sort
+      list-sort := <type-of; derw-type> l
 
   add-typeanno-to-list-tuples:
-    l@ListTail(elems, tail) -> TypedListTail(elems, tail, list-class)
+    l@ListTail(elems, tail) -> Cast(ListTail(elems, tail), list-sort)
     where
-      list-sort := <type-of; derw-type> l;
-      list-class := <ds-to-interp-terms-types-name; qualify-term-class> list-sort 
+      list-sort := <type-of; derw-type> l 
   
   add-typeanno-to-list-tuples:
-    Cast(List([]), list-sort) -> TypedList([], <ds-to-interp-terms-types-name; qualify-term-class> list-sort)
-  
-  add-typeanno-to-list-tuples:
-    Formula(Match(List([]), rhs)) -> Formula(Match(TypedList([], list-class), rhs))
+    Formula(Match(List([]), rhs)) -> Formula(Match(Cast(List([]), list-sort), rhs))
     where
-      list-sort := <type-of; derw-type> rhs;
-      list-class := <ds-to-interp-terms-types-name; qualify-term-class> list-sort
+      list-sort := <type-of; derw-type> rhs
   
   add-typeanno-to-list-tuples:
-    LabelComp(Label(l), List([])) -> LabelComp(Label(l), TypedList([], list-class))
+    LabelComp(Label(l), List([])) -> LabelComp(Label(l), Cast(List([]), list-sort))
     where
-      list-sort := <lookup-def(|Components()); lookup-prop(|Type()); derw-type> l;
-      list-class := <ds-to-interp-terms-types-name; qualify-term-class> list-sort
+      list-sort := <lookup-def(|Components()); lookup-prop(|Type()); derw-type> l
   
   add-typeanno-to-list-tuples:
-    Cast(Tuple(t*), tuple-sort@TupleSort(_)) -> TypedTuple(t*, <ds-to-interp-terms-types-name; qualify-term-class> tuple-sort) 
-  
-  add-typeanno-to-list-tuples:
-    tup@Tuple(t*) -> TypedTuple(t*, tuple-class)
+    tup@Tuple(t*) -> Cast(Tuple(t*), tuple-sort)
     where
-      tuple-sort := <type-of; derw-type> tup;
-      tuple-class := <ds-to-interp-terms-types-name; qualify-term-class> tuple-sort
+      tuple-sort := <type-of; derw-type> tup
   
   add-typeanno-to-list-tuples:
-    MapKeys(t) -> TypedMapKeys(t, keylist-class)
+    MapKeys(t) -> Cast(MapKeys(t), <derw-type> ListType(k))
     where
-      MapType(k, _) := <type-of> t;
-      keylist-class := <derw-type; ds-to-interp-terms-types-name; qualify-term-class> ListType(k)
+      MapType(k, _) := <type-of> t
   
   add-typeanno-to-list-tuples:
-    MapValues(t) -> TypedMapValues(t, valuelist-class)
+    MapValues(t) -> Cast(MapValues(t), <derw-type> ListType(v))
     where
-      MapType(_, v) := <type-of> t;
-      valuelist-class := <derw-type; ds-to-interp-terms-types-name; qualify-term-class> ListType(v)
+      MapType(_, v) := <type-of> t
   
   add-typeanno-to-list-tuples:
     Relation(src, arr@NamedDynamicEmitted(_, arr-name, in-sort), Target(Tuple(tup-t*), o-rw*)) ->
-      Relation(src, arr, Target(TypedTuple(tup-t*, tuple-class), o-rw*))
+      Relation(src, arr, Target(Cast(Tuple(tup-t*), <derw-type> out-ty), o-rw*))
     where
       in-ty := <rw-type> in-sort;
-      ArrowType(_, out-ty) := <select-applicable-arrow-callsite; lookup-prop(|Type())> (<lookup-defs(|Arrows())> arr-name, in-ty);
-      tuple-class := <derw-type; ds-to-interp-terms-types-name; qualify-term-class> out-ty
+      ArrowType(_, out-ty) := <select-applicable-arrow-callsite; lookup-prop(|Type())> (<lookup-defs(|Arrows())> arr-name, in-ty)
+  
+  list-to-typedlist:
+    Cast(List(elems), list-sort) -> TypedList(elems, list-class)
+    where
+       list-class := <ds-to-interp-terms-types-name; qualify-term-class> list-sort
+  
+  list-to-typedlist:
+    Cast(ListTail(elems, tail), list-sort) -> TypedListTail(elems, tail, list-class)
+    where
+      list-class := <ds-to-interp-terms-types-name; qualify-term-class> list-sort
+  
+  list-to-typedlist:
+    Cast(Tuple(elems), tuple-sort) -> TypedTuple(elems, tuple-class)
+    where
+       tuple-class := <ds-to-interp-terms-types-name; qualify-term-class> tuple-sort
 
 rules /* desugaring concat */
 

--- a/dynsem/trans/backend/interpreter/desugar-for-interpreter.str
+++ b/dynsem/trans/backend/interpreter/desugar-for-interpreter.str
@@ -296,6 +296,16 @@ rules /* resugar list construction */
     Cast(Tuple(elems), tuple-sort) -> TypedTuple(elems, tuple-class)
     where
        tuple-class := <ds-to-interp-terms-types-name; qualify-term-class> tuple-sort
+  
+  list-to-typedlist:
+    Cast(MapKeys(t), list-sort) -> TypedMapKeys(t, keylist-class)
+    where
+      keylist-class := <ds-to-interp-terms-types-name; qualify-term-class> list-sort
+  
+  list-to-typedlist:
+    Cast(MapValues(t), list-sort) -> TypedMapValues(t, vallist-class)
+    where
+      vallist-class := <ds-to-interp-terms-types-name; qualify-term-class> list-sort
 
 rules /* desugaring concat */
 

--- a/dynsem/trans/backend/interpreter/lang-ast.str
+++ b/dynsem/trans/backend/interpreter/lang-ast.str
@@ -9,15 +9,15 @@ imports
 rules
   
   ds-to-interp-terms-module =
-    ?Module(_, <fetch-elem(?Signatures(sig*))>);
+    ?mod@Module(_, <fetch-elem(?Signatures(sig*))>);
     where(ds-to-interp-clean-target; ds-to-interp-gen-project);
-    <ds-to-interp-terms-signatures-top; ds-to-interp-write-classes(|<get-opt> TermPkg())> sig*;
-    <ds-to-interp-terms-types-signatures; MkSingleton; ds-to-interp-write-classes(|<get-opt> TopPkg())> sig*;
+    <ds-to-interp-terms-signatures-top; ds-to-interp-write-classes(|<get-opt> TermPkg())> mod;
+    <ds-to-interp-terms-types-signatures; MkSingleton; ds-to-interp-write-classes(|<get-opt> TopPkg())> mod;
     <ds-to-inter-terms-sortbuilding; ds-to-interp-write-classes(|<get-opt> BuildPkg())> sig*;
-    <ds-to-interp-terms-building; ds-to-interp-write-classes(|<get-opt> BuildPkg())> sig*;
-    <ds-to-interp-terms-matching; ds-to-interp-write-classes(|<get-opt> MatchPkg())> sig*;
+    <ds-to-interp-terms-building; ds-to-interp-write-classes(|<get-opt> BuildPkg())> mod;
+    <ds-to-interp-terms-matching; ds-to-interp-write-classes(|<get-opt> MatchPkg())> mod;
     <ds-to-interp-nattypes-adapters-top; ds-to-interp-write-classes(|<get-opt> BuildPkg())> sig*;
-    <ds-to-interp-terms-registry-top; MkSingleton; ds-to-interp-write-classes(|<get-opt> TopPkg())> sig*;
+    <ds-to-interp-terms-registry-top; MkSingleton; ds-to-interp-write-classes(|<get-opt> TopPkg())> mod;
     ds-to-interp-language; MkSingleton; ds-to-interp-write-classes(|<get-opt> TopPkg());
     ds-to-interp-language-entrypoint; MkSingleton; ds-to-interp-write-classes(|<get-opt> TopPkg());
     ds-to-interp-language-daemonentry; MkSingleton; ds-to-interp-write-classes(|<get-opt> TopPkg());
@@ -33,12 +33,14 @@ rules
 rules /* Sort & Constructor classes */
 
   ds-to-interp-terms-signatures-top:
-    sig* -> [sort-class*, cons-class*, tuple-class*, list-class*]
+    mod@Module(_, section*) -> [sort-class*, cons-class*, tuple-class*, list-class*]
+    where
+      <fetch-elem(?Signatures(sig*))> section*
     where
       sort-dec* := <fetch-elem(?Sorts(<id>))> sig*;
       cons-dec* := <fetch-elem(?Constructors(<id>))> sig*;
       list-dec* := <get-languagelist-usage-in-signatures> sig*;
-      tuple-dec* := <get-languagetuple-usage-in-signatures> sig*;
+      tuple-dec* := <get-languagetuple-usage-in-module> mod;
       sort-class* := <map(ds-to-interp-terms-sortdecl(|cons-dec*))> sort-dec*;
       cons-class* := <map(ds-to-interp-terms-consdecl)> cons-dec*;
       tuple-class* := <map(ds-to-interp-terms-tupledecl)> tuple-dec*;
@@ -51,7 +53,10 @@ rules /* Sort & Constructor classes */
       implicit-map-key* := <collect-all(\ MapSort(k, _) -> ListSort(k) \); nub> sig;
       implicit-map-val* := <collect-all(\ MapSort(_, v) -> ListSort(v) \); nub> sig
   
-  get-languagetuple-usage-in-signatures = collect-all(?TupleSort(_)); nub
+  get-languagetuple-usage-in-module =
+    ?Module(_, _);
+    collect-all(?TupleSort(_));
+    nub
   
   ds-to-interp-terms-sortdecl(|cons-dec*):
     dec@SortDecl(s) ->
@@ -734,7 +739,7 @@ rules /* Sort & Constructor classes */
 rules /* type system class */
 
   ds-to-interp-terms-types-signatures:
-    sig-sec* ->
+    mod@Module(_, section*) ->
       compilation-unit |[
         package ~x:<get-opt> TopPkg();
 
@@ -749,11 +754,12 @@ rules /* type system class */
           
         }
       ]|
-    where 
+    where
+      <fetch-elem(?Signatures(sig-sec*))> section*;
       decl* := <filter(?Sorts(<id>) + ?Constructors(<id>) + ?NativeDataTypes(<id>)); concat;
         qsort(?(ConsDecl(_, _, _, _), SortDecl(_)) + ?(SortDecl(_), NativeBaseTypeDecl(_, _, _)) + ?(ConsDecl(_, _, _, _), NativeBaseTypeDecl(_, _, _)))> sig-sec*;
       list* := <get-languagelist-usage-in-signatures> sig-sec*;
-      tuple* := <get-languagetuple-usage-in-signatures> sig-sec*;
+      tuple* := <get-languagetuple-usage-in-module> mod;
       ![decl*, tuple*, list*];
       map(ds-to-interp-terms-types-name);
       map(!Lit(Class(ClassOrInterfaceType(TypeName(Id(<id>)), None())))); nub => type*
@@ -795,11 +801,13 @@ rules /* term building */
       x_expectmethod := $[expect[x_sortclass]]
 
   ds-to-interp-terms-building:
-    sig* -> [con-build*, list-build*, tuple-build*]
+    mod@Module(_, section*) -> [con-build*, list-build*, tuple-build*]
     where
+      <fetch-elem(?Signatures(sig*))> section*;
       con-dec* := <fetch-elem(?Constructors(<id>))> sig*;
       list-dec* := <get-languagelist-usage-in-signatures> sig*;
-      tuple-dec* := <get-languagetuple-usage-in-signatures> sig*;
+      tuple-dec* := <get-languagetuple-usage-in-module> mod;
+      debug(!"Tuples: ");
       con-build* := <map(ds-to-interp-terms-building-con)> con-dec*;
       list-build* := <map(ds-to-interp-terms-building-list)> list-dec*;
       tuple-build* := <map(ds-to-interp-terms-building-tuple)> tuple-dec*
@@ -954,11 +962,12 @@ rules /* term building */
 rules /* term matching */
 
   ds-to-interp-terms-matching:
-    sig* -> [con-match*, list-match*, tuple-match*]
+    mod@Module(_, section*) -> [con-match*, list-match*, tuple-match*]
     where
+      <fetch-elem(?Signatures(sig*))> section*;
       con-dec* := <fetch-elem(?Constructors(<id>))> sig*;
       list-dec* := <get-languagelist-usage-in-signatures> sig*;
-      tuple-dec* := <get-languagetuple-usage-in-signatures> sig*;
+      tuple-dec* := <get-languagetuple-usage-in-module> mod;
       con-match* := <map(ds-to-interp-terms-matching-con)> con-dec*;
       list-match* := <map(ds-to-interp-terms-matching-list)> list-dec*;
       tuple-match* := <map(ds-to-interp-terms-matching-tuple)> tuple-dec*

--- a/dynsem/trans/backend/interpreter/lang-ast.str
+++ b/dynsem/trans/backend/interpreter/lang-ast.str
@@ -385,6 +385,7 @@ rules /* Sort & Constructor classes */
         import org.apache.commons.lang3.builder.HashCodeBuilder;
         import org.metaborg.meta.lang.dynsem.interpreter.nodes.matching.ITermInstanceChecker;
         import org.metaborg.meta.lang.dynsem.interpreter.terms.IListTerm;
+        import org.metaborg.meta.lang.dynsem.interpreter.utils.ListUtils;
         import com.github.krukow.clj_lang.IPersistentStack;
         import com.github.krukow.clj_lang.PersistentList;
         import com.github.krukow.clj_lang.ISeq;
@@ -495,6 +496,11 @@ rules /* Sort & Constructor classes */
               backend = _cons(backend, elems[idx]);
             }
             return new x_listclass(backend, getStrategoTerm());
+          }
+          
+          @Override
+          public x_listclass reverse() {
+            return new x_listclass(ListUtils.reverse(backend), null);
           }
           
           @Override

--- a/dynsem/trans/backend/interpreter/lang-ast.str
+++ b/dynsem/trans/backend/interpreter/lang-ast.str
@@ -813,7 +813,6 @@ rules /* term building */
       con-dec* := <fetch-elem(?Constructors(<id>))> sig*;
       list-dec* := <get-languagelist-usage-in-signatures> sig*;
       tuple-dec* := <get-languagetuple-usage-in-module> mod;
-      debug(!"Tuples: ");
       con-build* := <map(ds-to-interp-terms-building-con)> con-dec*;
       list-build* := <map(ds-to-interp-terms-building-list)> list-dec*;
       tuple-build* := <map(ds-to-interp-terms-building-tuple)> tuple-dec*

--- a/dynsem/trans/backend/interpreter/lang-termregistry.str
+++ b/dynsem/trans/backend/interpreter/lang-termregistry.str
@@ -10,7 +10,7 @@ imports
 rules /* term registry */
 
   ds-to-interp-terms-registry-top:
-    sig* ->
+    mod@Module(_, section*) ->
       compilation-unit |[
         package ~x:<get-opt> TopPkg();
         
@@ -117,10 +117,11 @@ rules /* term registry */
       }
       ]|
     where
+      <fetch-elem(?Signatures(sig*))> section*;
       decl* := <filter(?Constructors(<id>) + ?NativeOperators(<id>) + ?NativeDataTypes(<id>)); concat> sig*;
       (consdecl*, (natopdecl*, nattydecl*)) := <partition(?ConsDecl(_, _, _, _)); (id, partition(?NativeOpDecl(_, _, _)))> decl*;
       list-dec* := <get-languagelist-usage-in-signatures> sig*;
-      tuple-dec* := <get-languagetuple-usage-in-signatures> sig*;
+      tuple-dec* := <get-languagetuple-usage-in-module> mod;
       x_classname := $[[<get-opt> LangName()]TermRegistry]; 
       bstm0* := <ds-to-interp-terms-registry-inits> consdecl*;
       bstm1* := <ds-to-interp-natopterms-registry-inits> natopdecl*;

--- a/dynsem/trans/backend/interpreter/project.str
+++ b/dynsem/trans/backend/interpreter/project.str
@@ -110,7 +110,7 @@ rules
             <dependency>
               <groupId>org.metaborg</groupId>
               <artifactId>org.metaborg.meta.lang.dynsem.interpreter</artifactId>
-              <version>2.2.0-SNAPSHOT</version>
+              <version>2.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
               <groupId>com.oracle.truffle</groupId>
@@ -126,7 +126,7 @@ rules
             <dependency>
               <groupId>org.metaborg</groupId>
               <artifactId>org.spoofax.terms</artifactId>
-              <version>2.2.0-SNAPSHOT</version>
+              <version>2.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
               <groupId>com.martiansoftware</groupId>

--- a/dynsem/trans/backend/interpreter/test-harness.str
+++ b/dynsem/trans/backend/interpreter/test-harness.str
@@ -112,10 +112,10 @@ rules
             final StringBuilder outBuilder = new StringBuilder();
             outBuilder.append(new String(outputStream.toByteArray()));
 
-            if (errorStream.size() > 0) {
-              outBuilder.append(new String(errorStream.toByteArray()));
-              outBuilder.append(System.lineSeparator());
-            }
+//            if (errorStream.size() > 0) {
+//              outBuilder.append(new String(errorStream.toByteArray()));
+//              outBuilder.append(System.lineSeparator());
+//            }
             assertEquals(expectedOutput.trim(), outBuilder.toString().trim());
           }
         

--- a/dynsem/trans/ds.str
+++ b/dynsem/trans/ds.str
@@ -4,7 +4,9 @@ imports
 	signatures/ds-sig
 	signatures/dynsem/Common-sig
 	analysis/constructors
-
+  completion/completion
+  completion/dynsem/-
+  
 imports
 	pp
 	outline

--- a/dynsem/trans/ds.str
+++ b/dynsem/trans/ds.str
@@ -25,8 +25,15 @@ signature
 
 rules // Analysis
 	
+	editor-analyze:
+	 (ast, _, _) -> (ast, [], [], [])
+	 where
+	   <?() <+ ?Module-Plhdr()> ast
+	
   editor-analyze:
     (ast, path, project-path) -> (analyzed-ast, error*, warning*, note*)
+    where
+      <not(?() <+ ?Module-Plhdr())> ast
 		with {| MyCurrentFile:
 		  f-path := $[[project-path]/[path]];
 		  rules(MyCurrentFile: _ -> f-path);

--- a/dynsem/trans/ds2ds/core.str
+++ b/dynsem/trans/ds2ds/core.str
@@ -26,6 +26,7 @@ strategies
       ; desugar-top
       ; desugar-meta-functions-top
       ; fuse-sections
+      ; desugar-guarded-binds-module
       ; desugar-varschemes-module
       ; add-extra-typeannos-module
       ; desugar-aliases-module

--- a/dynsem/trans/ds2ds/desugar-guarded-binds.str
+++ b/dynsem/trans/ds2ds/desugar-guarded-binds.str
@@ -1,0 +1,80 @@
+module ds2ds/desugar-guarded-binds
+
+imports
+  signatures/-
+  analysis/-
+
+rules
+  
+  desugar-guarded-binds-module = Module(id, alltd(desugar-guarded-binds))
+  
+  desugar-guarded-binds:
+    GuardedBind(v, guarded-value*) -> p
+    where
+      [p] := <foldr(![], desugar-guarded-bind(|v))> guarded-value*
+  
+  desugar-guarded-bind(|v):
+    (UValue(t), _) -> [Formula(Match(t, v))]
+  
+  desugar-guarded-bind(|v):
+    (GValue(t, ct), p*) -> [CaseMatch(Cast(ct, <derw-type> BoolType()), [case_positive, case_negative])]
+    where
+      case_positive := CasePattern(True(), [Formula(Match(t, v))]);
+      case_negative := CaseOtherwise(p*)
+  
+  desugar-guarded-bind(|v):
+    (NegGValue(t, ct), p*) -> [CaseMatch(Cast(ct, <derw-type> BoolType()), [case_positive, case_negative])]
+    where
+      case_positive := CasePattern(False(), [Formula(Match(t, v))]);
+      case_negative := CaseOtherwise(p*) 
+  
+      
+    
+    
+//      type-check-premise:
+//    f@GuardedBind(v, guarded-value*) -> f
+//    where
+//      <map(try(type-check-guarded-value(|v)))> guarded-value*;
+//      if (_, [_|_]) := <split-fetch(?UValue(_))> guarded-value*
+//      then
+//        add-msg(|Warning(), guarded-value*, $[Contains unreachble assignments])
+//      end
+//  
+//  type-check-guarded-value(|v):
+//    UValue(t) -> <type-check-premise> Formula(Match(t, v))
+//  
+//  type-check-guarded-value(|v):
+//    guarded-value -> <type-check-premise> Formula(Match(t, v))
+//    where
+//      ?GValue(t, ct) + ?NegGValue(t, ct)
+//    where
+//      ct-ty := <type-check-build> ct;
+//      <type-coerce-full(fail)> (ct-ty, BoolType())
+  
+//  
+//  
+//  copy-propagation-module = Module(id, alltd(copy-propagation-rule))
+//
+//  copy-propagation-rule:
+//    Rule(prem*, infer, Relation(reads, source, arrow, Target(rhs, tc*))) ->
+//      Rule(prem'*, infer, Relation(reads, source, arrow, Target(rhs', tc'*)))
+//    where {| PropagateCopy:
+//      prem'* := <filter(copy-propagation)> prem*;
+//      rhs' := <copy-propagation-prop> rhs;
+//      tc'* := <copy-propagation-prop> tc*
+//    |}
+//  
+//  copy-propagation-premises = is-list;  {| PropagateCopy: filter(copy-propagation) |}
+//  
+//  copy-propagation =
+//    not(copy-propagation-prop; copy-propagation-rec);
+//    copy-propagation-prop
+//  
+//  copy-propagation-prop = alltd(VarRef(PropagateCopy))
+//  
+//  copy-propagation-rec:
+//    f@Formula(Match(VarRef(var1), VarRef(var2))) -> f
+//    where
+//      rules(PropagateCopy:+ var2 -> var1)
+
+

--- a/dynsem/trans/ds2ds/desugar-guarded-binds.str
+++ b/dynsem/trans/ds2ds/desugar-guarded-binds.str
@@ -27,54 +27,5 @@ rules
     where
       case_positive := CasePattern(False(), [Formula(Match(t, v))]);
       case_negative := CaseOtherwise(p*) 
-  
-      
-    
-    
-//      type-check-premise:
-//    f@GuardedBind(v, guarded-value*) -> f
-//    where
-//      <map(try(type-check-guarded-value(|v)))> guarded-value*;
-//      if (_, [_|_]) := <split-fetch(?UValue(_))> guarded-value*
-//      then
-//        add-msg(|Warning(), guarded-value*, $[Contains unreachble assignments])
-//      end
-//  
-//  type-check-guarded-value(|v):
-//    UValue(t) -> <type-check-premise> Formula(Match(t, v))
-//  
-//  type-check-guarded-value(|v):
-//    guarded-value -> <type-check-premise> Formula(Match(t, v))
-//    where
-//      ?GValue(t, ct) + ?NegGValue(t, ct)
-//    where
-//      ct-ty := <type-check-build> ct;
-//      <type-coerce-full(fail)> (ct-ty, BoolType())
-  
-//  
-//  
-//  copy-propagation-module = Module(id, alltd(copy-propagation-rule))
-//
-//  copy-propagation-rule:
-//    Rule(prem*, infer, Relation(reads, source, arrow, Target(rhs, tc*))) ->
-//      Rule(prem'*, infer, Relation(reads, source, arrow, Target(rhs', tc'*)))
-//    where {| PropagateCopy:
-//      prem'* := <filter(copy-propagation)> prem*;
-//      rhs' := <copy-propagation-prop> rhs;
-//      tc'* := <copy-propagation-prop> tc*
-//    |}
-//  
-//  copy-propagation-premises = is-list;  {| PropagateCopy: filter(copy-propagation) |}
-//  
-//  copy-propagation =
-//    not(copy-propagation-prop; copy-propagation-rec);
-//    copy-propagation-prop
-//  
-//  copy-propagation-prop = alltd(VarRef(PropagateCopy))
-//  
-//  copy-propagation-rec:
-//    f@Formula(Match(VarRef(var1), VarRef(var2))) -> f
-//    where
-//      rules(PropagateCopy:+ var2 -> var1)
-
-
+ 
+ 

--- a/dynsem/trans/ds2ds/expand-implicits.str
+++ b/dynsem/trans/ds2ds/expand-implicits.str
@@ -141,6 +141,12 @@ rules /* lift and expand subterms on build sides */
       MapType(k-ty, v-ty) := <type-of> m;
       (k', p1*) := <lift-where-indirect <+ !(k, [])> (k-ty, k);
       (v', p2*) := <lift-where-indirect <+ !(v, [])> (v-ty, v)
+  
+  expand-implicits-termbuild:
+    MapUnbind(map, key) -> (MapUnbind(map, key'), p1*)
+    where
+      MapType(k-ty, v-ty) := <type-of> map;
+      (key', p1*) := <lift-where-indirect <+ !(key, [])> (k-ty, key)
 
   expand-implicits-termbuild:
     LabelComp(Label(l), t) -> (LabelComp(Label(l), t'), p*)

--- a/dynsem/trans/ds2ds/expand-implicits.str
+++ b/dynsem/trans/ds2ds/expand-implicits.str
@@ -128,6 +128,13 @@ rules /* lift and expand subterms on build sides */
       ListType(f-l-ty) := <type-of> l-t;
       (idx-t', p*) := <lift-where-indirect <+ !(idx-t, [])> (f-l-ty, idx-t)
 
+  // map has check
+  expand-implicits-termbuild:
+    MapHas(m-t, k-t) -> (MapHas(m-t, k-t'), p*)
+    where
+      MapType(f-k-ty, _) := <type-of> m-t;
+      (k-t', p*) := <lift-where-indirect <+ !(k-t, [])> (f-k-ty, k-t)
+
   expand-implicits-termbuild:
     MapExtend(Map([Bind(k, v)]), m) -> (MapExtend(Map([Bind(k', v')]), m), [p1*, p2*])
     where

--- a/dynsem/trans/ds2ds/expand-implicits.str
+++ b/dynsem/trans/ds2ds/expand-implicits.str
@@ -154,6 +154,13 @@ rules /* lift and expand subterms on build sides */
       ty := <lookup-def(|Components()); lookup-prop(|Type())> l;
       (t', p*) := <lift-where-indirect> (ty, t)
 
+  expand-implicits-termbuild:
+    c@Concat(t1, t2) -> (Concat(t1', t2'), [p1*, p2*])
+    where
+      StringType() := <type-of> c;
+      (t1', p1*) := <lift-where-indirect> (StringType(), t1);
+      (t2', p2*) := <lift-where-indirect> (StringType(), t2) 
+
   lift-where-indirect:
     (e-ty, t) -> (VarRef(v-new), [Formula(Match(t, Var(v-new)))])
     where

--- a/dynsem/trans/ds2ds/extra-typeannos.str
+++ b/dynsem/trans/ds2ds/extra-typeannos.str
@@ -18,7 +18,7 @@ rules
     Rule(p*, infer, Relation(Reads(r*), Source(lhs, sc*), arr@NamedDynamicEmitted(_, arrow-name), Target(t, tc*))) -> 
       Rule(p*, infer, Relation(Reads(r*), Source(lhs, sc*), arr, Target(Cast(t, bu-ty-str), tc*)))
     where
-      <?List([]) + ?Map([])> t
+      <?List([]) + ?Map([]) + ?Tuple(_)> t
     where
       ArrowType(ma-ty, bu-ty) := <resolve-applicable-arrow-defsite; lookup-prop(|Type())> (arrow-name, <type-of> lhs);
       bu-ty-str := <derw-type> bu-ty

--- a/dynsem/trans/ds2ds/factorize.str
+++ b/dynsem/trans/ds2ds/factorize.str
@@ -235,6 +235,13 @@ rules
       (prem2*, v') := <lift-build-on-cond(is-build-nonprime-factor, ?success)> v;
       !success
   
+  factorize-map-in-build:
+    MapUnbind(map, key) -> ([prem1*, prem2*], MapUnbind(map', key'))
+    where
+      (prem1*, map') := <lift-build-on-cond(is-build-nonprime-factor, ?success)> map;
+      (prem2*, key') := <lift-build-on-cond(is-build-nonprime-factor, ?success)> key;
+      !success
+  
   factorize-mapextend-in-build:
     MapExtend(l, r) -> ([prem1*, prem2*], MapExtend(l', r'))
     where

--- a/dynsem/trans/ds2ds/sugar.str
+++ b/dynsem/trans/ds2ds/sugar.str
@@ -108,9 +108,6 @@ rules // desugaring
     Axiom(form) -> Rule([], "---------", form)
     
   desugar :
-    IsValue(term) -> TermEq(Con("IsValue",[term]),Con("True",[]))
-
-  desugar :
     Map([b | b*@[_|_]]) -> MapExtend(Map([b]), Map(b*))
     
   desugar :
@@ -179,7 +176,4 @@ rules // sugaring
 
   sugar :
   	Source(term,[]) -> Source(term)
-
-  sugar :
-    TermEq(Con("IsValue",[term]),Con("True",[])) -> IsValue(term)
 

--- a/dynsem/trans/pp.str
+++ b/dynsem/trans/pp.str
@@ -6,9 +6,28 @@ imports
   libspoofax/sdf/pp
   signatures/-
   pp/-
-  pp/ds-parenthesize
+  pp/dynsem/-
   ds
-  
+
+rules
+  pp-ds-string =
+    parenthesize-ds
+    ; prettyprint-ds-start-symbols
+    ; !V([], <id>)
+    ; box2text-string(|120)
+      
+  pp-partial-ds-string =
+    parenthesize-ds
+    ; prettyprint-ds
+    ; !V([], <id>)
+    ; box2text-string(|120)
+    
+  pp-partial-ds-string(|sort) =
+    parenthesize-ds
+    ; prettyprint-ds(|sort)
+    ; !V([], <id>)
+    ; box2text-string(|120)  
+      
 rules
   
   prettyprint-Var :

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/DynSemContext.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/DynSemContext.java
@@ -23,6 +23,7 @@ public class DynSemContext {
 
 	private final InputStream input;
 	private final PrintStream output;
+	private final PrintStream err;
 
 	private final IDynSemLanguageParser parser;
 	private final ITermRegistry termRegistry;
@@ -31,16 +32,17 @@ public class DynSemContext {
 	private final Map<String, Object> config;
 
 	public DynSemContext(IDynSemLanguageParser parser, ITermRegistry termRegistry, RuleRegistry ruleRegistry) {
-		this(parser, termRegistry, ruleRegistry, System.in, System.out, new HashMap<String, Object>());
+		this(parser, termRegistry, ruleRegistry, System.in, System.out, System.err, new HashMap<String, Object>());
 	}
 
 	public DynSemContext(IDynSemLanguageParser parser, ITermRegistry termRegistry, RuleRegistry ruleRegistry,
-			InputStream input, PrintStream output, Map<String, Object> config) {
+			InputStream input, PrintStream output, PrintStream err, Map<String, Object> config) {
 		this.parser = parser;
 		this.termRegistry = termRegistry;
 		this.ruleRegistry = ruleRegistry;
 		this.input = input;
 		this.output = output;
+		this.err = err;
 		this.config = config;
 	}
 
@@ -129,6 +131,14 @@ public class DynSemContext {
 	 */
 	public PrintStream getOutput() {
 		return output;
+	}
+
+	/**
+	 * 
+	 * @return a reference to the error {@link OutputStream} configured for this {@link DynSemContext}
+	 */
+	public PrintStream getErr() {
+		return err;
 	}
 
 }

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/DynSemLanguage.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/DynSemLanguage.java
@@ -27,7 +27,7 @@ public abstract class DynSemLanguage extends TruffleLanguage<DynSemContext> {
 	public abstract boolean isSafeComponentsEnabled();
 
 	public abstract boolean isTermCachingEnabled();
-	
+
 	public abstract boolean isDEBUG();
 
 	@Override
@@ -36,7 +36,8 @@ public abstract class DynSemLanguage extends TruffleLanguage<DynSemContext> {
 		IDynSemLanguageParser parser = (IDynSemLanguageParser) config.get(PARSER);
 		ITermRegistry termRegistry = (ITermRegistry) config.get(TERM_REGISTRY);
 		RuleRegistry ruleRegistry = (RuleRegistry) config.get(RULE_REGISTRY);
-		return new DynSemContext(parser, termRegistry, ruleRegistry, env.in(), new PrintStream(env.out()), config);
+		return new DynSemContext(parser, termRegistry, ruleRegistry, env.in(), new PrintStream(env.out()),
+				new PrintStream(env.err()), config);
 	}
 
 	public Node createFindContextNode0() {

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/building/Fresh.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/building/Fresh.java
@@ -9,7 +9,7 @@ import com.oracle.truffle.api.source.SourceSection;
 
 public class Fresh extends TermBuild {
 
-	private static int next = Integer.MIN_VALUE;
+	private static int next = 0;
 
 	public Fresh(SourceSection source) {
 		super(source);

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/building/ListReverseTermBuild.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/building/ListReverseTermBuild.java
@@ -21,15 +21,8 @@ public abstract class ListReverseTermBuild extends TermBuild {
 	@SuppressWarnings("rawtypes")
 	@Specialization
 	public IListTerm doEvaluated(IListTerm l) {
-		
-		return null;
+		return l.reverse();
 	}
-
-	// @SuppressWarnings({ "rawtypes", "unchecked" })
-	// @Specialization
-	// public IListTerm doLists(IListTerm l, IListTerm r){
-	// return r.addAll(l.toArray());
-	// }
 
 	public static ListReverseTermBuild create(IStrategoAppl t, FrameDescriptor fd) {
 		assert Tools.hasConstructor(t, "Reverse", 1);

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/building/ListReverseTermBuild.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/building/ListReverseTermBuild.java
@@ -1,0 +1,42 @@
+package org.metaborg.meta.lang.dynsem.interpreter.nodes.building;
+
+import org.metaborg.meta.lang.dynsem.interpreter.terms.IListTerm;
+import org.metaborg.meta.lang.dynsem.interpreter.utils.SourceSectionUtil;
+import org.spoofax.interpreter.core.Tools;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.FrameDescriptor;
+import com.oracle.truffle.api.source.SourceSection;
+
+@NodeChildren({ @NodeChild(value = "list", type = TermBuild.class) })
+public abstract class ListReverseTermBuild extends TermBuild {
+
+	public ListReverseTermBuild(SourceSection source) {
+		super(source);
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Specialization
+	public IListTerm doEvaluated(IListTerm l) {
+		
+		return null;
+	}
+
+	// @SuppressWarnings({ "rawtypes", "unchecked" })
+	// @Specialization
+	// public IListTerm doLists(IListTerm l, IListTerm r){
+	// return r.addAll(l.toArray());
+	// }
+
+	public static ListReverseTermBuild create(IStrategoAppl t, FrameDescriptor fd) {
+		assert Tools.hasConstructor(t, "Reverse", 1);
+
+		TermBuild list = TermBuild.create(Tools.applAt(t, 0), fd);
+
+		return ListReverseTermBuildNodeGen.create(SourceSectionUtil.fromStrategoTerm(t), list);
+	}
+
+}

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/building/MapUnbindBuild.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/building/MapUnbindBuild.java
@@ -1,0 +1,40 @@
+package org.metaborg.meta.lang.dynsem.interpreter.nodes.building;
+
+import org.metaborg.meta.lang.dynsem.interpreter.utils.MapUtils;
+import org.metaborg.meta.lang.dynsem.interpreter.utils.SourceSectionUtil;
+import org.spoofax.interpreter.core.Tools;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+
+import com.github.krukow.clj_ds.PersistentMap;
+import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.FrameDescriptor;
+import com.oracle.truffle.api.source.SourceSection;
+
+@NodeChildren({ @NodeChild(value = "map", type = TermBuild.class), @NodeChild(value = "key", type = TermBuild.class) })
+public abstract class MapUnbindBuild extends TermBuild {
+
+	public MapUnbindBuild(SourceSection source) {
+		super(source);
+	}
+
+	public static MapUnbindBuild create(IStrategoAppl t, FrameDescriptor fd) {
+		CompilerAsserts.neverPartOfCompilation();
+		assert Tools.hasConstructor(t, "MapUnbind", 2);
+		TermBuild map = TermBuild.create(Tools.applAt(t, 0), fd);
+		TermBuild key = TermBuild.create(Tools.applAt(t, 1), fd);
+
+		return MapUnbindBuildNodeGen.create(SourceSectionUtil.fromStrategoTerm(t), map, key);
+	}
+
+	@Specialization
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@TruffleBoundary
+	public PersistentMap<?, ?> doEvaluated(PersistentMap map, Object key) {
+		return MapUtils.remove(map, key);
+	}
+
+}

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/building/TermBuild.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/building/TermBuild.java
@@ -125,6 +125,11 @@ public abstract class TermBuild extends DynSemNode {
 		if (Tools.hasConstructor(t, "ListConcat", 2)) {
 			return ListConcatTermBuildNodeGen.create(t, fd);
 		}
+
+		if (Tools.hasConstructor(t, "Reverse", 1)) {
+			return ListReverseTermBuildNodeGen.create(t, fd);
+		}
+
 		if (Tools.hasConstructor(t, "TypedTuple", 2)) {
 			return TupleBuild.create(t, fd);
 		}

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/building/TermBuild.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/nodes/building/TermBuild.java
@@ -86,16 +86,19 @@ public abstract class TermBuild extends DynSemNode {
 		if (Tools.hasConstructor(t, "MapExtend", 2)) {
 			return MapExtendBuild.create(t, fd);
 		}
+		if (Tools.hasConstructor(t, "MapUnbind", 2)) {
+			return MapUnbindBuild.create(t, fd);
+		}
 		if (Tools.hasConstructor(t, "DeAssoc", 2)) {
 			return DeAssoc.create(t, fd);
 		}
 		if (Tools.hasConstructor(t, "MapHas", 2)) {
 			return MapHas.create(t, fd);
 		}
-		if(Tools.hasConstructor(t, "TypedMapKeys", 2)){
+		if (Tools.hasConstructor(t, "TypedMapKeys", 2)) {
 			return TypedMapKeys.create(t, fd);
 		}
-		if(Tools.hasConstructor(t, "TypedMapValues", 2)){
+		if (Tools.hasConstructor(t, "TypedMapValues", 2)) {
 			return TypedMapValues.create(t, fd);
 		}
 		if (Tools.hasConstructor(t, "True", 0)) {
@@ -110,7 +113,7 @@ public abstract class TermBuild extends DynSemNode {
 		if (Tools.hasConstructor(t, "String", 1)) {
 			return StringLiteralTermBuild.create(t, fd);
 		}
-		if(Tools.hasConstructor(t, "StrConcat", 2)){
+		if (Tools.hasConstructor(t, "StrConcat", 2)) {
 			return StringConcatTermBuild.create(t, fd);
 		}
 		if (Tools.hasConstructor(t, "ListSource", 2)) {
@@ -119,7 +122,7 @@ public abstract class TermBuild extends DynSemNode {
 		if (Tools.hasConstructor(t, "TypedList", 2) || Tools.hasConstructor(t, "TypedListTail", 3)) {
 			return ListBuild.create(t, fd);
 		}
-		if(Tools.hasConstructor(t, "ListConcat", 2)){
+		if (Tools.hasConstructor(t, "ListConcat", 2)) {
 			return ListConcatTermBuildNodeGen.create(t, fd);
 		}
 		if (Tools.hasConstructor(t, "TypedTuple", 2)) {
@@ -136,7 +139,7 @@ public abstract class TermBuild extends DynSemNode {
 			// the cast
 			return TermBuild.create(Tools.applAt(t, 0), fd);
 		}
-		if(Tools.hasConstructor(t, "TermPlaceholder", 0)) {
+		if (Tools.hasConstructor(t, "TermPlaceholder", 0)) {
 			return TermPlaceholderBuild.create(t, fd);
 		}
 

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/terms/IListTerm.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/terms/IListTerm.java
@@ -67,18 +67,24 @@ public interface IListTerm<T> extends ITerm {
 	 * 
 	 * @param elems
 	 *            an array of elements to be appended
-	 * @return a new {@link IListTerm} containing the prepended elements from <code>elems</code> followed by the elements of this {@link IListTerm}
+	 * @return a new {@link IListTerm} containing the prepended elements from <code>elems</code> followed by the
+	 *         elements of this {@link IListTerm}
 	 */
 	public IListTerm<T> addAll(T[] elems);
 
-	
-	
+	/**
+	 * Reverse this list. The new list will contain the same elements but in reverse order
+	 * 
+	 * @return a new {@link IListTerm} containing the same items but in reverse order
+	 */
+	public IListTerm<T> reverse();
+
 	/**
 	 * 
 	 * @return an iterator for this {@link IListTerm}
 	 */
 	public Iterator<T> iterator();
-	
+
 	/**
 	 * @return an array containing all of the elements in this list
 	 */

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/utils/InterpreterUtils.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/utils/InterpreterUtils.java
@@ -86,4 +86,23 @@ public final class InterpreterUtils {
 
 		return str.toString();
 	}
+
+	public static int stackDepth() {
+		final StringBuilder str = new StringBuilder();
+		Truffle.getRuntime().iterateFrames(new FrameInstanceVisitor<Integer>() {
+
+			@Override
+			public Integer visitFrame(FrameInstance frameInstance) {
+				CallTarget callTarget = frameInstance.getCallTarget();
+				RootNode rn = ((RootCallTarget) callTarget).getRootNode();
+				if (rn.getClass().getName().contains("DynSemRuleForeignAccess")) {
+					return 1;
+				}
+				str.append(" ");
+				return null;
+			}
+
+		});
+		return str.length();
+	}
 }

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/utils/ListUtils.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/utils/ListUtils.java
@@ -1,13 +1,22 @@
 package org.metaborg.meta.lang.dynsem.interpreter.utils;
 
+import java.util.LinkedList;
+
 import com.github.krukow.clj_lang.IPersistentStack;
+import com.github.krukow.clj_lang.PersistentList;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 
 public class ListUtils {
-	
+
 	@TruffleBoundary
 	public static <T> IPersistentStack<T> reverse(IPersistentStack<T> list) {
-		throw new RuntimeException("List reversal not implemented");
+		final PersistentList<T> plist = (PersistentList<T>) list;
+
+		final LinkedList<T> temp = new LinkedList<>();
+		for (T t : plist) {
+			temp.add(t);
+		}
+		return PersistentList.create(temp);
 	}
 
 }

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/utils/ListUtils.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/utils/ListUtils.java
@@ -10,6 +10,9 @@ public class ListUtils {
 
 	@TruffleBoundary
 	public static <T> IPersistentStack<T> reverse(IPersistentStack<T> list) {
+		if (list.count() == 0) {
+			return list;
+		}
 		final PersistentList<T> plist = (PersistentList<T>) list;
 
 		final LinkedList<T> temp = new LinkedList<>();

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/utils/ListUtils.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/utils/ListUtils.java
@@ -1,0 +1,13 @@
+package org.metaborg.meta.lang.dynsem.interpreter.utils;
+
+import com.github.krukow.clj_lang.IPersistentStack;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+
+public class ListUtils {
+	
+	@TruffleBoundary
+	public static <T> IPersistentStack<T> reverse(IPersistentStack<T> list) {
+		throw new RuntimeException("List reversal not implemented");
+	}
+
+}

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/utils/ListUtils.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/utils/ListUtils.java
@@ -1,6 +1,7 @@
 package org.metaborg.meta.lang.dynsem.interpreter.utils;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.Collections;
 
 import com.github.krukow.clj_lang.IPersistentStack;
 import com.github.krukow.clj_lang.PersistentList;
@@ -13,13 +14,12 @@ public class ListUtils {
 		if (list.count() == 0) {
 			return list;
 		}
-		final PersistentList<T> plist = (PersistentList<T>) list;
 
-		final LinkedList<T> temp = new LinkedList<>();
-		for (T t : plist) {
-			temp.add(t);
-		}
-		return PersistentList.create(temp);
+		final ArrayList<T> mlist = new ArrayList<T>((PersistentList<T>) list);
+
+		Collections.reverse(mlist);
+
+		return PersistentList.create(mlist);
 	}
 
 }

--- a/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/utils/MapUtils.java
+++ b/org.metaborg.meta.lang.dynsem.interpreter/src/main/java/org/metaborg/meta/lang/dynsem/interpreter/utils/MapUtils.java
@@ -32,6 +32,11 @@ public class MapUtils {
 	}
 
 	@TruffleBoundary
+	public static <K, V> PersistentMap<K, V> remove(PersistentMap<K, V> map, K key) {
+		return map.minus(key);
+	}
+
+	@TruffleBoundary
 	public static <K, V> V get(PersistentMap<K, V> map, K key) {
 		return map.get(key);
 	}


### PR DESCRIPTION
Quite often we end up writing something like this:

```
  lookup-local-method(RefV(S'), x) --> v
  where
    read(S') --> Obj(_, _, _, methods);
    case methods[x?] of {
      true =>
        methods[x] => v
      false =>
        DoneV() => v
    }.
```

Where we really are just trying to guard the looking in `methods` otherwise set a default. Sometimes it gets a bit more complicated:

```
  lookup-outer-method(RefV(S'), x) --> v
  where
    read(S') --> Obj(O', _, _, methods);
    case methods[x?] of {
      true =>
        methods[x] => v
      false =>
        is-stored(O') --> outer-exists;
        case outer-exists of {
          true =>
            lookup-outer-method(O', x) --> v
          otherwise =>
            DoneV() => v
        }
    }.
```

And the intention of the specification gets lost in the noise.

Introducing multiple variable binds with guards. Multiple variable binds with guards allow us to encode the behavior intended above more concisely.

The first rule above becomes:

```
  lookup-local-method(RefV(S'), x) --> v
  where
    read(S') --> Obj(_, _, _, methods);
    v as methods[x] if methods[x?]
       or DoneV().
```

We're saying `v` becomes `method[x]` *if*  x is in methods, *or* it becomes `DoneV()` otherwise.

The second rule above encodes 3 cases, and they are nested into each other, a typically noisy scenario. We can now rewrite it as:

```
  lookup-outer-method(RefV(S'), x) --> v
  where
    read(S') --> Obj(O', _, _, methods);
    v as methods[x] if methods[x?]
       or lookup-outer-method(O', x) if is-stored(O')
       or DoneV().
```

taking advantage of the new feature and of the implicit expansion of meta-functions.

The LHS (`v` in the case above) can be any term valid in pattern match position; the term after the *if* (the guard) has to be a `Bool` or be reducible to a `Bool`. The means one can use the multiple variable binding pattern to assign to multiple values at once:

```
(v, EX) as (vret, Ok()) if eqI(r-mark', r-mark)
            or (vcode, EX1)
```

The new feature is implemented as a desugaring step applied early in the DynSem-to-Core transformation. 